### PR TITLE
Add Quanton Operator public cert for JWT verification

### DIFF
--- a/charts/quanton-operator-chart/templates/quanton-operator-cert-secret.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-cert-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.onehouseConfig.quantonOperatorPublicCert }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: quanton-operator-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: onehouse-quanton-operator
+    app.kubernetes.io/component: quanton-operator
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    app.kubernetes.io/managed-by: quanton-operator
+type: Opaque
+data:
+  public-cert.pem: {{ .Values.onehouseConfig.quantonOperatorPublicCert | b64enc | quote }}
+{{- end }}

--- a/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
@@ -20,5 +20,6 @@ data:
       "gwcEndpoint": {{ .Values.onehouseConfig.endpoint | quote }},
       "metricsEndpoint": {{ .Values.onehouseConfig.metricsEndpoint | quote }},
       "mtlsCertPath": "/etc/mtls/client-cert.pem",
-      "mtlsKeyPath": "/etc/mtls/client-key.pem"
+      "mtlsKeyPath": "/etc/mtls/client-key.pem",
+      "quantonOperatorCertPath": "/etc/quanton-operator-cert/public-cert.pem"
     }

--- a/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
@@ -143,6 +143,9 @@ spec:
         - name: mtls-certs
           mountPath: /etc/mtls
           readOnly: true
+        - name: quanton-operator-cert
+          mountPath: /etc/quanton-operator-cert
+          readOnly: true
 
       # OTel Collector sidecar (for metrics/telemetry export)
       # Always enabled - degrades gracefully if export endpoint unreachable
@@ -237,6 +240,10 @@ spec:
       - name: mtls-certs
         secret:
           secretName: mutual-tls-secret
+          defaultMode: 0400
+      - name: quanton-operator-cert
+        secret:
+          secretName: quanton-operator-cert
           defaultMode: 0400
 
       {{- with .Values.quantonOperator.nodeSelector }}

--- a/charts/quanton-operator-chart/values.yaml
+++ b/charts/quanton-operator-chart/values.yaml
@@ -15,6 +15,10 @@ onehouseConfig:
     clientCert: ""  # Client certificate (PEM format, will be base64-encoded in K8s secret)
     clientKey: ""   # Client private key (PEM format, will be base64-encoded in K8s secret)
 
+  # Per-org public certificate signed by the Quanton Operator CA.
+  # Used to verify JWT token signatures. Must be provided at install time.
+  quantonOperatorPublicCert: ""  # PEM format
+
   imagePullSecrets:
     accessToken: ""
 


### PR DESCRIPTION
## Summary
- Adds new `quanton-operator-cert-secret.yaml` template to store the per-org public certificate as a K8s secret
- Mounts the cert into the operator deployment at `/etc/quanton-operator-cert/`
- Adds `quantonOperatorCertPath` to operator config
- Adds `onehouseConfig.quantonOperatorPublicCert` to `values.yaml`

## Test plan
- [ ] Deploy with `quantonOperatorPublicCert` set — verify secret is created and mounted
- [ ] Deploy without `quantonOperatorPublicCert` — verify secret is not created
- [ ] Verify operator config JSON includes `quantonOperatorCertPath`

🤖 Generated with [Claude Code](https://claude.com/claude-code)