### PR TITLE
Mount JWT token as file instead of env variable

### DIFF
--- a/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
@@ -21,5 +21,6 @@ data:
       "metricsEndpoint": {{ .Values.onehouseConfig.metricsEndpoint | quote }},
       "mtlsCertPath": "/etc/mtls/client-cert.pem",
       "mtlsKeyPath": "/etc/mtls/client-key.pem",
-      "quantonOperatorCertPath": "/etc/quanton-operator-cert/public-cert.pem"
+      "quantonOperatorCertPath": "/etc/quanton-operator-cert/public-cert.pem",
+      "jwtTokenPath": "/etc/jwt-token/JWT_TOKEN"
     }

--- a/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
@@ -90,15 +90,6 @@ spec:
             fieldRef:
               fieldPath: status.podIP
 
-        # JWT Token for Control Plane auth (if configured)
-        {{- if .Values.onehouseConfig.authToken }}
-        - name: ONEHOUSE_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: onehouse-token
-              key: JWT_TOKEN
-        {{- end }}
-
         # Path to operator config file (mounted from ConfigMap)
         - name: OPERATOR_CONFIG_PATH
           value: "/etc/quanton-operator/config.json"
@@ -145,6 +136,9 @@ spec:
           readOnly: true
         - name: quanton-operator-cert
           mountPath: /etc/quanton-operator-cert
+          readOnly: true
+        - name: jwt-token
+          mountPath: /etc/jwt-token
           readOnly: true
 
       # OTel Collector sidecar (for metrics/telemetry export)
@@ -245,6 +239,11 @@ spec:
         secret:
           secretName: quanton-operator-cert
           defaultMode: 0400
+      - name: jwt-token
+        secret:
+          secretName: onehouse-token
+          defaultMode: 0400
+          optional: true
 
       {{- with .Values.quantonOperator.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Summary
- Removes `ONEHOUSE_TOKEN` env var from the operator deployment
- Mounts the `onehouse-token` secret as a file at `/etc/jwt-token/JWT_TOKEN`
- Adds `jwtTokenPath` to operator config pointing to the mounted token
- Secret is marked `optional: true` for deployments without an auth token

## Test plan
- [ ] Deploy with auth token configured — verify token file is mounted and operator reads it
- [ ] Deploy without auth token — verify deployment starts successfully (optional secret)
- [ ] Verify `ONEHOUSE_TOKEN` env var is no longer present in the pod spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)