### PR TITLE
Make quanton-operator-cert secret optional

### DIFF
--- a/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
@@ -239,6 +239,7 @@ spec:
         secret:
           secretName: quanton-operator-cert
           defaultMode: 0400
+          optional: true
       - name: jwt-token
         secret:
           secretName: onehouse-token


### PR DESCRIPTION
## Summary
- Adds `optional: true` to the `quanton-operator-cert` secret volume in the operator deployment
- Prevents `FailedMount` errors when `quantonOperatorPublicCert` is not configured

## Test plan
- [ ] Deploy without `quantonOperatorPublicCert` set — verify pod starts without mount errors
- [ ] Deploy with `quantonOperatorPublicCert` set — verify cert is mounted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)