### PR TITLE
Add helm chart version to config and namespace RBAC

### DIFF
--- a/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
@@ -14,5 +14,6 @@ data:
       "otelServiceName": "quanton-operator",
       "additionalSparkParamsToMask": {{ .Values.quantonOperator.additionalSparkParamsToMask | toJson }},
       "mtlsCertPath": "/etc/mtls/client-cert.pem",
-      "mtlsKeyPath": "/etc/mtls/client-key.pem"
+      "mtlsKeyPath": "/etc/mtls/client-key.pem",
+      "helmChartVersion": {{ .Chart.Version | quote }}
     }

--- a/charts/quanton-operator-chart/templates/quanton-operator-rbac.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-rbac.yaml
@@ -105,6 +105,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get


### PR DESCRIPTION
## Summary
- Add `helmChartVersion` field to operator config, populated from `.Chart.Version`, for version tracking
- Add RBAC `get` permission on `namespaces` resource for the operator

## Test plan
- [ ] Verify `helm template` renders `helmChartVersion` correctly
- [ ] Confirm operator can get namespace resources after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)