### PR TITLE
Add conditional cluster-wide secret permissions when jobNamespaces is empty

### DIFF
--- a/charts/quanton-operator-chart/templates/quanton-operator-rbac.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-rbac.yaml
@@ -78,6 +78,21 @@ rules:
   - update
   - watch
 
+{{- if not .Values.quantonOperator.jobNamespaces }}
+# Broad secret management - no jobNamespaces specified, grant cluster-wide access
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- else }}
 # Scoped secret management - restricted to operator-managed secrets only
 # Operator needs to read/update these secrets for image pull credentials and mTLS
 - apiGroups:
@@ -101,6 +116,7 @@ rules:
   - create
   - list
   - watch
+{{- end }}
 
 - apiGroups:
   - ""


### PR DESCRIPTION
## Summary
- When `jobNamespaces` is empty/unset, the ClusterRole now grants broad secret permissions (all CRUD verbs) cluster-wide so the operator can manage secrets in any namespace
- When `jobNamespaces` is configured, the existing least-privilege approach is preserved: named secrets only in the ClusterRole, plus per-namespace Roles for job namespaces

## Test plan
- [ ] `helm template` with empty `jobNamespaces` — verify ClusterRole has broad secret verbs and no per-namespace Roles are generated
- [ ] `helm template` with `jobNamespaces: [ns-a, ns-b]` — verify ClusterRole has scoped secret rules (resourceNames) and per-namespace Roles are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)