### PR TITLE
Add enableAIAgent config to operator

### DIFF
--- a/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-config.yaml
@@ -15,5 +15,6 @@ data:
       "additionalSparkParamsToMask": {{ .Values.quantonOperator.additionalSparkParamsToMask | toJson }},
       "mtlsCertPath": "/etc/mtls/client-cert.pem",
       "mtlsKeyPath": "/etc/mtls/client-key.pem",
-      "helmChartVersion": {{ .Chart.Version | quote }}
+      "helmChartVersion": {{ .Chart.Version | quote }},
+      "enableAIAgent": {{ .Values.onehouseConfig.enableAIAgent }}
     }

--- a/charts/quanton-operator-chart/values.yaml
+++ b/charts/quanton-operator-chart/values.yaml
@@ -11,6 +11,9 @@ onehouseConfig:
 
   quantonSparkImage: "dist.onehouse.ai/onehouseai/quanton-spark:release-v1.29.0-al2023"
 
+  # Enable AI agent plugin for Spark applications
+  enableAIAgent: true
+
 # Quanton Operator configuration
 quantonOperator:
   # Namespaces where Spark jobs will run


### PR DESCRIPTION
## Summary
- Adds `enableAIAgent` boolean flag to `onehouseConfig` in Helm values (default: `true`)
- Passes the new flag through to the operator config ConfigMap

## Test plan
- [ ] Verify `helm template` renders the config correctly with default value
- [ ] Verify overriding `onehouseConfig.enableAIAgent=false` works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)