### PR TITLE
Simplify OTel collector config and rename billing pipeline

### DIFF
--- a/charts/quanton-operator-chart/templates/otel-collector-config.yaml
+++ b/charts/quanton-operator-chart/templates/otel-collector-config.yaml
@@ -1,4 +1,3 @@
-{{- /* OTEL Collector config (always created) */}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,20 +9,7 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 data:
   config.yaml: |
-    # OpenTelemetry Collector Configuration for Quanton Operator
-    # This configuration exports metrics and traces to Onehouse Control Plane
-
     receivers:
-      # Prometheus receiver for metrics from the operator
-      prometheus:
-        config:
-          scrape_configs:
-            - job_name: 'quanton-operator'
-              scrape_interval: 15s
-              static_configs:
-                - targets: ['localhost:8080']
-
-      # OTLP receiver for traces and metrics from applications
       otlp:
         protocols:
           grpc:
@@ -31,13 +17,7 @@ data:
           http:
             endpoint: 0.0.0.0:4318
 
-      # Prometheus receiver scraping the kube-state-metrics sidecar for pod billing metrics every 60s.
-      # Metrics collected:
-      #   kube_pod_labels                        - all pod labels (used to filter oh-quanton=true pods)
-      #   kube_pod_container_resource_requests   - CPU/memory requests per container
-      #   kube_pod_container_resource_limits     - CPU/memory limits per container
-      #   kube_pod_status_phase                  - pod phase (Running/Pending/Failed/Succeeded/Unknown)
-      prometheus/billing:
+      prometheus/ksm:
         config:
           scrape_configs:
             - job_name: 'kube-state-metrics'
@@ -46,47 +26,16 @@ data:
                 - targets: ['localhost:8082']
 
     processors:
-      # Batch processor for efficient batching
       batch:
         send_batch_size: 100
         timeout: 10s
 
-      # Attributes processor to add resource attributes
-      attributes:
-        actions:
-          - key: service.name
-            value: quanton-operator
-            action: insert
-          - key: cluster.name
-            value: {{ .Release.Namespace }}
-            action: insert
-
-      # Resource processor to add source label to all forwarded metrics
-      resource/source:
-        attributes:
-          - key: source
-            value: "quanton-operator"
-            action: upsert
-
-      # Memory limiter to prevent OOM
       memory_limiter:
         check_interval: 1s
         limit_mib: 256
         spike_limit_mib: 128
 
-      # Resource detection
-      resourcedetection/env:
-        detectors: [env, system]
-        timeout: 2s
-
-      # ── Billing pipeline processors ──────────────────────────────────────
-      # Output: OTLP gRPC → operator port 4320 (billingserver)
-      # The operator converts the OTLP payload to ControlPlaneSyncRequest{billing:...}
-      # and calls OrgManagementService/ControlPlaneSync.
-
-      # Drop pods not in the configured job namespaces (when namespace-restricted mode is active).
-      # kube-state-metrics exposes namespace as a datapoint label (metric attribute).
-      filter/billing:
+      filter/ksm:
         error_mode: ignore
         metrics:
           datapoint:
@@ -97,47 +46,17 @@ data:
             {{- end }}
             - 'not ({{ join " or " $nsParts }})'
             {{- end }}
-            # kube_pod_status_phase emits one datapoint per (pod, phase) with value 1 for the
-            # active phase and 0 for all others. Drop the inactive (zero-valued) datapoints.
             - 'metric.name == "kube_pod_status_phase" and value_double == 0'
 
     exporters:
-      # File exporter to persist metrics to disk
-      file:
-        path: "/var/log/otel-metrics/metrics.json"
-        format: "json"
-        rotation:
-          max_megabytes: 100
-          max_days: 7
-          max_backups: 5
-
-      # Debug exporter for debugging (optional)
-      debug:
-        verbosity: detailed
-
-      # Prometheus remote write exporter to forward metrics to metrics endpoint.
-      # Writes to the operator's metrics proxy (localhost:8093) which decides
-      # whether to forward based on the derived metricsEndpoint.
-      prometheusremotewrite/dp:
-        endpoint: "http://localhost:8093/api/v1/write"
-        tls:
-          insecure: true
-        resource_to_telemetry_conversion:
-          enabled: true
-
-      # OTLP gRPC exporter to the operator's billing gRPC server (port 4320).
-      # The operator converts OTLP to ControlPlaneSyncRequest{billing:...} and
-      # calls OrgManagementService/ControlPlaneSync.
-      # Metrics are persisted to disk via file_storage/billing so they survive
-      # network failures and are retried automatically when connectivity is restored.
-      otlp/billing:
+      otlp/operator:
         endpoint: localhost:4320
         tls:
           insecure: true
         compression: none
         sending_queue:
           enabled: true
-          storage: file_storage/billing
+          storage: file_storage/queue
           num_consumers: 1
           queue_size: 5000
         retry_on_failure:
@@ -150,28 +69,14 @@ data:
       health_check:
         endpoint: :13133
 
-      # Persistent storage for the billing queue. Metrics written here survive
-      # network failures and are retried when the connection to port 4320 is restored.
-      file_storage/billing:
-        directory: /var/log/otel-billing-queue
+      file_storage/queue:
+        directory: /var/log/otel-queue
         timeout: 10s
 
     service:
-      extensions: [health_check, file_storage/billing]
+      extensions: [health_check, file_storage/queue]
       pipelines:
-        # Operator self-metrics pipeline
         metrics:
-          receivers: [prometheus, otlp]
-          processors: [memory_limiter, attributes, resource/source, resourcedetection/env, batch]
-          exporters: [file, debug, prometheusremotewrite/dp]
-
-        # Traces pipeline
-        traces:
-          receivers: [otlp]
-          processors: [memory_limiter, attributes, resourcedetection/env, batch]
-          exporters: [debug]
-
-        metrics/billing:
-          receivers: [prometheus/billing]
-          processors: [memory_limiter, filter/billing, batch]
-          exporters: [otlp/billing]
+          receivers: [prometheus/ksm]
+          processors: [memory_limiter, filter/ksm, batch]
+          exporters: [otlp/operator]

--- a/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
@@ -133,6 +133,8 @@ spec:
         - name: mtls-certs
           mountPath: /etc/mtls
           readOnly: true
+        - name: metrics-queue-storage
+          mountPath: /var/log/operator-metrics-queue
       # OTel Collector sidecar (for metrics/telemetry export)
       # Always enabled - degrades gracefully if export endpoint unreachable
       - name: otel-collector
@@ -179,11 +181,11 @@ spec:
           readOnly: true
         - name: metrics-storage
           mountPath: /var/log/otel-metrics
-        - name: billing-queue-storage
-          mountPath: /var/log/otel-billing-queue
+        - name: otel-queue-storage
+          mountPath: /var/log/otel-queue
 
-      # kube-state-metrics sidecar: exposes kube_pod_labels Prometheus metric with all pod labels.
-      # Scoped to job namespaces only. OTEL prometheus/billing receiver scrapes localhost:8082.
+      # kube-state-metrics sidecar: exposes pod resource metrics.
+      # Scoped to job namespaces only. OTEL prometheus/ksm receiver scrapes localhost:8082.
       - name: kube-state-metrics
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         imagePullPolicy: IfNotPresent
@@ -221,7 +223,9 @@ spec:
           defaultMode: 0644
       - name: metrics-storage
         emptyDir: {}
-      - name: billing-queue-storage
+      - name: otel-queue-storage
+        emptyDir: {}
+      - name: metrics-queue-storage
         emptyDir: {}
       - name: mtls-certs
         secret:


### PR DESCRIPTION
## Summary
- Removes unused OTel exporters (file, debug, prometheusremotewrite) and pipelines (traces, self-metrics)
- Consolidates to a single metrics pipeline: `prometheus/ksm` → `filter/ksm` → `otlp/operator`
- Renames `billing-queue-storage` volume to `otel-queue-storage` and adds `metrics-queue-storage` volume for the operator container

## Test plan
- [ ] Verify `helm template` renders correctly with no missing references
- [ ] Confirm OTel collector starts healthy with the simplified config
- [ ] Verify KSM metrics still flow through the pipeline to the operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)