### PR TITLE
Remove unused metrics-queue-storage volume from operator

### DIFF
--- a/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
+++ b/charts/quanton-operator-chart/templates/quanton-operator-deployment.yaml
@@ -133,8 +133,6 @@ spec:
         - name: mtls-certs
           mountPath: /etc/mtls
           readOnly: true
-        - name: metrics-queue-storage
-          mountPath: /var/log/operator-metrics-queue
       # OTel Collector sidecar (for metrics/telemetry export)
       # Always enabled - degrades gracefully if export endpoint unreachable
       - name: otel-collector
@@ -224,8 +222,6 @@ spec:
       - name: metrics-storage
         emptyDir: {}
       - name: otel-queue-storage
-        emptyDir: {}
-      - name: metrics-queue-storage
         emptyDir: {}
       - name: mtls-certs
         secret:


### PR DESCRIPTION
## Summary
- Removes the `metrics-queue-storage` emptyDir volume and its volumeMount from the operator container, as it is no longer needed

## Test plan
- [ ] Verify Helm template renders without errors (`helm template`)
- [ ] Deploy and confirm operator pod starts successfully without the volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)