### PR TITLE
Add Hudi and Iceberg clustering demos + run-clustering Claude skill

### DIFF
--- a/.claude/skills/run-clustering/SKILL.md
+++ b/.claude/skills/run-clustering/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: run-clustering
+description: Run the Hudi or Iceberg clustering demo on minikube — writes a 100-row table with a complex (Struct/Array/Map/nested) schema, forces a many-tiny-files layout, then triggers the format's native clustering procedure with spark.quanton.clustering.accelerate=true and verifies it succeeded
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# Run Quanton Clustering Demo: Hudi and/or Iceberg
+
+You are a guided demo agent for Quanton's native clustering acceleration. Run the chosen demo, give live progress, and report whether clustering succeeded.
+
+The demos live in `examples/`:
+
+| Format | Manifest | Script |
+|---|---|---|
+| Hudi | `examples/clustering-demo/quanton-hudi-clustering-demo.yaml` | `examples/clustering-demo/hudi_clustering_demo.py` |
+| Iceberg | `examples/clustering-demo/quanton-iceberg-clustering-demo.yaml` | `examples/clustering-demo/iceberg_clustering_demo.py` |
+
+Each manifest is a self-contained ConfigMap (inline script) + PVC + QuantonSparkApplication. Both write 100 rows with a complex schema, force a many-tiny-files layout, then call the native clustering procedure with `spark.quanton.clustering.accelerate=true`.
+
+## Phase 0: Interactive Configuration
+
+Use AskUserQuestion. Keep it short — the demo is small.
+
+### Q1: Which format?
+
+> "Which clustering demo should I run?"
+
+Options:
+- **Hudi only** — `run_clustering(order='region,ts', op='scheduleandexecute')`
+- **Iceberg only** — `rewrite_data_files(strategy='sort', sort_order='region ASC, ts ASC')`
+- **Both** — Hudi then Iceberg, sequentially (PVCs are independent so they don't conflict, but pods are scheduled serially for clarity)
+
+### Q2: Cluster check (no question — just verify)
+
+Run:
+```bash
+kubectl config current-context
+```
+Confirm it's `minikube`. If it's any other context, stop and tell the user to `kubectl config use-context minikube` first.
+
+Then:
+```bash
+helm list -A | grep -E "spark-operator|quanton-operator"
+```
+If either operator is missing, stop and tell the user to run `/setup-and-run-example` first.
+
+## Phase 1: Run the demo
+
+For each chosen format:
+
+### 1. Clean up any prior run
+
+```bash
+kubectl delete -f examples/clustering-demo/quanton-<fmt>-clustering-demo.yaml --ignore-not-found
+kubectl delete pvc quanton-<fmt>-clustering-demo-pvc -n default --ignore-not-found
+```
+
+### 2. Apply the manifest
+
+```bash
+kubectl apply -f examples/clustering-demo/quanton-<fmt>-clustering-demo.yaml
+```
+
+Tell the user: "Submitted `quanton-<fmt>-clustering-demo`. The Quanton operator will provision the driver + executor pods. The first run pulls the Quanton spark image (~3.5 GB on minikube) and, for Hudi, downloads `hudi-spark3.5-bundle:0.15.0` from Maven Central — expect a 1–3 min cold start."
+
+### 3. Live progress
+
+Poll every ~20s until the QuantonSparkApplication phase is `COMPLETED` or `FAILED`:
+
+```bash
+kubectl get quantonsparkapplication quanton-<fmt>-clustering-demo -n default \
+  -o jsonpath='{.status.phase}'
+```
+
+Between polls, give the user a one-line status update:
+- **UNKNOWN**: "Operator reconciling, driver not yet scheduled..."
+- **RUNNING**: "Driver pod running — generating data and running clustering."
+- **COMPLETED** / **FAILED**: stop polling, move to step 4.
+
+If the user asks for more detail mid-flight, tail the driver log:
+```bash
+kubectl logs -n default quanton-<fmt>-clustering-demo-driver --tail=20
+```
+
+### 4. Report the outcome
+
+After the CRD reaches a terminal phase, grep the driver log for the demo's own status lines:
+
+```bash
+kubectl logs -n default quanton-<fmt>-clustering-demo-driver 2>&1 \
+  | grep -E "<fmt>-clustering|PASS|FAIL"
+```
+
+The demos print clear markers:
+
+- **Hudi** `PASS` looks like:
+  ```
+  [hudi-clustering] On-disk parquet files: 50 -> 51 (Hudi keeps old files; new ones + .replacecommit are added)
+  [hudi-clustering] .replacecommit files in .hoodie/: 1
+  [hudi-clustering] PASS — 100 rows preserved, 1 replacecommit(s) on timeline
+  ```
+- **Iceberg** `PASS` looks like:
+  ```
+  [iceberg-clustering] Files: 40 -> 1
+  [iceberg-clustering] PASS — 100 rows preserved, files compacted 40 -> 1
+  ```
+
+Surface those lines verbatim to the user and call out the file-count change. **Do not present wall-times** — the demos use tiny 100-row tables where startup dominates and Hudi vs Iceberg timings are not comparable; surfacing them invites misleading conclusions. If the demo failed, also tail the last 50 log lines and surface any `Exception` / `Caused by` lines.
+
+### 5. (Optional) Native-acceleration markers
+
+If the user asks "did Quanton's native path actually engage?" — grep the driver log:
+
+```bash
+kubectl logs -n default quanton-<fmt>-clustering-demo-driver 2>&1 \
+  | grep -iE "NativeClusteringGroupWriter|libvelox.so|VeloxBackend|Components registered"
+```
+
+Look for:
+- `Loaded clustering group writer: quanton-velox-clustering-0x (ai.onehouse.hudi.clustering.NativeClusteringGroupWriterImpl)` — Hudi native writer engaged
+- `libvelox.so has been loaded` / `Components registered within order: velox, velox-hudi, velox-delta, velox-iceberg` — Quanton's native engine up
+  (the literal strings come from the runtime; they're the markers to grep for)
+
+Note: `acceleratedStages: 0` from `QuantonAccelerationTracker` does **not** mean acceleration is off — the tracker only counts natively-accelerated *Spark query stages*, not the Hudi/Iceberg clustering procedure code paths. The native writer can be active even when this counter is 0.
+
+## Phase 2: Cleanup (optional)
+
+Ask the user: "Demo finished. Should I clean up the resources?"
+
+- Options: "Clean up everything" / "Keep them for inspection"
+
+If clean up:
+```bash
+kubectl delete -f examples/clustering-demo/quanton-<fmt>-clustering-demo.yaml --ignore-not-found
+kubectl delete pvc quanton-<fmt>-clustering-demo-pvc -n default --ignore-not-found
+```
+
+(The PVC is named `quanton-<fmt>-clustering-demo-pvc`; it's gitignored from the chart and safe to delete.)
+
+## Caveats
+
+- **Apple Silicon (M1/M2/M3):** Older Quanton spark images (`release-v0.2.0-al2023` and earlier) only ship a Graviton SVE2 build of the native engine and will `SIGILL` on aarch64 Mac. The `release-v0.9.0-al2023` and later images include an aarch64 build that works on Apple Silicon.
+- **Hudi clustering file count:** Hudi tombstones old files via the `.hoodie` timeline (`.replacecommit`) instead of physically deleting them. The Hudi demo asserts on the timeline, not on the parquet-file count.
+- **Iceberg jars on the Quanton image:** Bundled at `/opt/spark/user-jars/`. The manifest uses `spark.{driver,executor}.extraClassPath` to put them on the classpath; do NOT add iceberg via `spark.jars.packages` in parallel — a second shaded-parquet copy on the classpath breaks with a `ClassCastException`.

--- a/examples/clustering-demo/README.md
+++ b/examples/clustering-demo/README.md
@@ -1,0 +1,92 @@
+# Quanton Clustering Demo
+
+End-to-end clustering demos for Apache Hudi and Apache Iceberg on minikube,
+exercising Quanton's native clustering acceleration via the
+`spark.quanton.clustering.accelerate=true` feature flag.
+
+Each demo writes 100 rows with a complex schema (`Struct` / `Array` / `Map` /
+nested struct-of-array), forces a many-tiny-files layout, then runs the
+format's native clustering procedure with sort-by columns.
+
+| Format | Manifest | Script | Clustering procedure |
+|---|---|---|---|
+| Hudi | [`quanton-hudi-clustering-demo.yaml`](quanton-hudi-clustering-demo.yaml) | [`hudi_clustering_demo.py`](hudi_clustering_demo.py) | `CALL run_clustering(order='region,ts', op='scheduleandexecute')` |
+| Iceberg | [`quanton-iceberg-clustering-demo.yaml`](quanton-iceberg-clustering-demo.yaml) | [`iceberg_clustering_demo.py`](iceberg_clustering_demo.py) | `CALL rewrite_data_files(strategy='sort', sort_order='region ASC, ts ASC')` |
+
+## Prerequisites
+
+- minikube running with at least 4 CPUs / 8 GB RAM
+- Spark Operator and Quanton Operator already installed and `Running`
+  (see [`../../README.md`](../../README.md))
+
+## Run
+
+### Hudi
+
+```bash
+kubectl apply -f quanton-hudi-clustering-demo.yaml
+kubectl logs -f quanton-hudi-clustering-demo-driver -n default
+```
+
+Expected tail:
+
+```
+[hudi-clustering] On-disk parquet files: 50 -> 51 (Hudi keeps old files; new ones + .replacecommit are added)
+[hudi-clustering] .replacecommit files in .hoodie/: 1
+[hudi-clustering] PASS — 100 rows preserved, 1 replacecommit(s) on timeline
+```
+
+### Iceberg
+
+```bash
+kubectl apply -f quanton-iceberg-clustering-demo.yaml
+kubectl logs -f quanton-iceberg-clustering-demo-driver -n default
+```
+
+Expected tail:
+
+```
+[iceberg-clustering] Files: 40 -> 1
+[iceberg-clustering] PASS — 100 rows preserved, files compacted 40 -> 1
+```
+
+## Files
+
+| File | Role |
+|---|---|
+| `quanton-hudi-clustering-demo.yaml` | ConfigMap (inline `hudi_clustering_demo.py`) + 2 Gi PVC + QuantonSparkApplication. Sets `spark.quanton.clustering.accelerate: "true"`. |
+| `quanton-iceberg-clustering-demo.yaml` | Same shape for Iceberg. Adds `spark.{driver,executor}.extraClassPath` pointing at the iceberg jars bundled in the Quanton image (see notes below). |
+| `hudi_clustering_demo.py` | Standalone source — generates 100 complex-schema rows, writes a Hudi COW table with `hoodie.parquet.max.file.size=1024` (1 KiB) to force many tiny files, calls `run_clustering`, asserts a `.replacecommit` appears on the timeline. |
+| `iceberg_clustering_demo.py` | Standalone source — creates a Hadoop-catalog Iceberg table, writes 20 sequential 5-row batches (→ ~40 small data files), calls `rewrite_data_files(strategy='sort')`, asserts file count decreased. |
+
+## Cleanup
+
+```bash
+kubectl delete -f quanton-hudi-clustering-demo.yaml
+kubectl delete -f quanton-iceberg-clustering-demo.yaml
+kubectl delete pvc quanton-hudi-clustering-demo-pvc quanton-iceberg-clustering-demo-pvc -n default
+```
+
+## Notes
+
+- **Apple Silicon (M1/M2/M3):** older Quanton spark images
+  (`release-v0.2.0-al2023` and earlier) only shipped a Graviton SVE2 build of
+  the native engine and `SIGILL` on aarch64 Mac. `release-v0.9.0-al2023` and
+  later include an aarch64 build that works on Apple Silicon.
+
+- **Iceberg jars on the Quanton image:** the Quanton spark image bundles
+  `iceberg-spark-runtime.jar`, `iceberg-aws-bundle.jar`, and
+  `iceberg-spark-quanton.jar` at `/opt/spark/user-jars/`. The Iceberg demo
+  manifest puts them on the classpath via `spark.{driver,executor}.extraClassPath`
+  rather than `spark.jars.packages` — pulling iceberg via maven on top of the
+  bundled jars puts two copies on the classpath with mismatched shaded-parquet
+  classes and breaks with a `ClassCastException` between
+  `org.apache.parquet.schema.MessageType` and the iceberg-shaded equivalent.
+
+- **Hudi clustering file count is not a reliable success signal:** Hudi
+  tombstones old files via the `.hoodie/` timeline (a new `.replacecommit`)
+  rather than deleting them on disk. The Hudi demo's assertion is on
+  `.replacecommit` count, not on parquet-file count.
+
+- **Trigger this demo via Claude Code:** run `/run-clustering` — see
+  [`../../.claude/skills/run-clustering/SKILL.md`](../../.claude/skills/run-clustering/SKILL.md).

--- a/examples/clustering-demo/hudi_clustering_demo.py
+++ b/examples/clustering-demo/hudi_clustering_demo.py
@@ -1,0 +1,139 @@
+"""
+hudi_clustering_demo.py — Hudi clustering demo with complex nested schema
+
+End-to-end Hudi clustering demo on a small (100-row) dataset:
+  1. Creates a Hudi COW table with a complex schema (Struct / Array / Map / nested),
+     forced to produce many tiny files via small hoodie.parquet.max.file.size.
+  2. Calls run_clustering(order='region,ts', op='scheduleandexecute') to compact
+     and sort the small files.
+  3. Verifies the file count decreased (clustering actually ran) and the data
+     comes back intact.
+
+On the Quanton image with spark.quanton.clustering.accelerate=true, the sort +
+write inside the clustering procedure run via Quanton's native group writer
+(ai.onehouse.hudi.clustering.NativeClusteringGroupWriterImpl).
+
+Usage:
+  spark-submit hudi_clustering_demo.py <outputDir>
+"""
+
+import os
+import sys
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+
+SORT_COLUMNS = "region,ts"
+ROWS = 100
+EVENT_TYPES = [f"event_{i:02d}" for i in range(8)]
+REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-south-1"]
+
+
+def count_parquet_files(table_path: str) -> int:
+    n = 0
+    for root, dirs, files in os.walk(table_path):
+        dirs[:] = [d for d in dirs if not d.startswith(".hoodie")]
+        for f in files:
+            if f.endswith(".parquet"):
+                n += 1
+    return n
+
+
+def count_replacecommits(table_path: str) -> int:
+    """A clustering operation appends a .replacecommit to .hoodie/. Use this as
+    the signal that clustering actually ran — Hudi doesn't physically delete
+    the old small files (they're tombstoned via the timeline), so a raw
+    parquet-file count is not a reliable check."""
+    timeline = os.path.join(table_path, ".hoodie")
+    if not os.path.isdir(timeline):
+        return 0
+    return sum(1 for f in os.listdir(timeline) if f.endswith(".replacecommit"))
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: hudi_clustering_demo.py <outputDir>")
+        sys.exit(1)
+
+    output_dir = sys.argv[1].rstrip("/")
+    table_path = f"{output_dir}/events_hudi"
+    table_name = "events_hudi"
+
+    spark = (SparkSession.builder
+             .appName("HudiClusteringDemo")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config("spark.kryo.registrator", "org.apache.spark.HoodieSparkKryoRegistrar")
+             .config("spark.sql.extensions", "org.apache.spark.sql.hudi.HoodieSparkSessionExtension")
+             .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.hudi.catalog.HoodieCatalog")
+             .getOrCreate())
+    spark.sparkContext.setLogLevel("WARN")
+
+    print(f"[hudi-clustering] Generating {ROWS} rows with complex schema -> {table_path}")
+    df = (spark.range(0, ROWS)
+          .withColumn("ts", F.expr("from_unixtime(unix_timestamp(current_timestamp()) - cast(rand(42) * 86400 * 90 as bigint))").cast("timestamp"))
+          .withColumn("region", F.element_at(F.array(*[F.lit(r) for r in REGIONS]),
+                                             (F.col("id") % len(REGIONS) + 1).cast("int")))
+          .withColumn("customer_id", F.concat(F.lit("cust-"), F.lpad((F.col("id") % 50).cast("string"), 4, "0")))
+          .withColumn("amount", (F.rand(7) * 1000.0).cast("decimal(15,2)"))
+          .withColumn("event_type", F.element_at(F.array(*[F.lit(e) for e in EVENT_TYPES]),
+                                                 (F.col("id") % len(EVENT_TYPES) + 1).cast("int")))
+          .withColumn("address", F.struct(
+              F.concat(F.lit("street-"), (F.col("id") % 99).cast("string")).alias("street"),
+              F.concat(F.lit("city-"), (F.col("id") % 20).cast("string")).alias("city"),
+              F.lpad((F.col("id") % 99999).cast("string"), 5, "0").alias("zip"),
+          ))
+          .withColumn("tags", F.array(F.concat(F.lit("tag-"), (F.col("id") % 5).cast("string")),
+                                      F.concat(F.lit("tag-"), (F.col("id") % 7).cast("string"))))
+          .withColumn("attributes", F.map_from_arrays(
+              F.array(F.lit("k1"), F.lit("k2")),
+              F.array(F.concat(F.lit("v-"), (F.col("id") % 3).cast("string")),
+                      F.concat(F.lit("v-"), (F.col("id") % 5).cast("string"))))))
+
+    # Force many tiny files: 1 KiB max → roughly one row per file.
+    (df.repartition(50)
+       .write.format("hudi")
+       .option("hoodie.table.name", table_name)
+       .option("hoodie.datasource.write.recordkey.field", "id")
+       .option("hoodie.datasource.write.precombine.field", "ts")
+       .option("hoodie.datasource.write.operation", "bulk_insert")
+       .option("hoodie.parquet.max.file.size", "1024")
+       .option("hoodie.parquet.small.file.limit", "0")
+       .option("hoodie.clustering.inline", "false")
+       .option("hoodie.clustering.async.enabled", "false")
+       .option("hoodie.metadata.enable", "false")
+       .option("hoodie.parquet.compression.codec", "zstd")
+       .mode("overwrite")
+       .save(table_path))
+
+    files_before = count_parquet_files(table_path)
+    print(f"[hudi-clustering] Wrote table with {files_before} small parquet files")
+
+    spark.sql(f"CREATE TABLE IF NOT EXISTS {table_name} USING hudi LOCATION '{table_path}'")
+
+    print(f"[hudi-clustering] CALL run_clustering(order='{SORT_COLUMNS}', op='scheduleandexecute')")
+    spark.sql(f"""
+        CALL run_clustering(
+          table => '{table_name}',
+          order => '{SORT_COLUMNS}',
+          op => 'scheduleandexecute'
+        )
+    """).collect()
+    files_after = count_parquet_files(table_path)
+    replacecommits = count_replacecommits(table_path)
+
+    print(f"[hudi-clustering] On-disk parquet files: {files_before} -> {files_after} "
+          f"(Hudi keeps old files; clustering adds new ones + a .replacecommit)")
+    print(f"[hudi-clustering] .replacecommit files in .hoodie/: {replacecommits}")
+    assert replacecommits >= 1, \
+        f"Expected at least one .replacecommit after clustering, got {replacecommits}"
+
+    rows = spark.sql(f"SELECT count(*) AS c FROM {table_name}").collect()[0]["c"]
+    assert rows == ROWS, f"Expected {ROWS} rows after clustering, got {rows}"
+    print(f"[hudi-clustering] PASS — {rows} rows preserved, {replacecommits} replacecommit(s) on timeline")
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/clustering-demo/iceberg_clustering_demo.py
+++ b/examples/clustering-demo/iceberg_clustering_demo.py
@@ -1,0 +1,121 @@
+"""
+iceberg_clustering_demo.py — Iceberg clustering demo with complex nested schema
+
+End-to-end Iceberg clustering demo on a small (100-row) dataset:
+  1. Creates an Iceberg table (Hadoop catalog) with a complex schema
+     (Struct / Array / Map), populated via repeated INSERT batches so the
+     table has many small data files.
+  2. Calls rewrite_data_files(strategy='sort', sort_order='region ASC, ts ASC')
+     to compact and sort the small files.
+  3. Verifies the file count decreased (clustering actually ran) and the data
+     comes back intact.
+
+On the Quanton image with spark.quanton.clustering.accelerate=true, the sort
+inside the rewrite_data_files procedure runs via Quanton-native execution.
+
+Usage:
+  spark-submit iceberg_clustering_demo.py <warehouseDir>
+"""
+
+import sys
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+
+SORT_ORDER = "region ASC NULLS LAST, ts ASC NULLS LAST"
+ROWS_PER_BATCH = 5
+BATCHES = 20  # 20 × 5 = 100 rows, written as 20 separate snapshots → 20+ data files
+EVENT_TYPES = [f"event_{i:02d}" for i in range(8)]
+REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-south-1"]
+
+
+def file_count(spark, table: str) -> int:
+    return int(spark.sql(f"SELECT count(*) AS c FROM {table}.files").collect()[0]["c"])
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: iceberg_clustering_demo.py <warehouseDir>")
+        sys.exit(1)
+
+    warehouse = sys.argv[1].rstrip("/")
+    table = "default.events_iceberg"
+
+    spark = (SparkSession.builder
+             .appName("IcebergClusteringDemo")
+             .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+             .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", warehouse)
+             .getOrCreate())
+    spark.sparkContext.setLogLevel("WARN")
+
+    print(f"[iceberg-clustering] Creating {table} in {warehouse}")
+    spark.sql(f"DROP TABLE IF EXISTS {table}")
+    spark.sql(f"""
+      CREATE TABLE {table} (
+        id BIGINT,
+        ts TIMESTAMP,
+        region STRING,
+        customer_id STRING,
+        amount DECIMAL(15,2),
+        event_type STRING,
+        address STRUCT<street: STRING, city: STRING, zip: STRING>,
+        tags ARRAY<STRING>,
+        attributes MAP<STRING, STRING>
+      )
+      USING iceberg
+      TBLPROPERTIES ('write.parquet.compression-codec' = 'zstd')
+    """)
+
+    # 20 sequential inserts of 5 rows each → 20+ small files
+    for b in range(BATCHES):
+        batch = (spark.range(b * ROWS_PER_BATCH, (b + 1) * ROWS_PER_BATCH)
+                 .withColumn("ts", F.expr("from_unixtime(unix_timestamp(current_timestamp()) - cast(rand(42) * 86400 * 90 as bigint))").cast("timestamp"))
+                 .withColumn("region", F.element_at(F.array(*[F.lit(r) for r in REGIONS]),
+                                                    (F.col("id") % len(REGIONS) + 1).cast("int")))
+                 .withColumn("customer_id", F.concat(F.lit("cust-"), F.lpad((F.col("id") % 50).cast("string"), 4, "0")))
+                 .withColumn("amount", (F.rand(7) * 1000.0).cast("decimal(15,2)"))
+                 .withColumn("event_type", F.element_at(F.array(*[F.lit(e) for e in EVENT_TYPES]),
+                                                        (F.col("id") % len(EVENT_TYPES) + 1).cast("int")))
+                 .withColumn("address", F.struct(
+                     F.concat(F.lit("street-"), (F.col("id") % 99).cast("string")).alias("street"),
+                     F.concat(F.lit("city-"), (F.col("id") % 20).cast("string")).alias("city"),
+                     F.lpad((F.col("id") % 99999).cast("string"), 5, "0").alias("zip"),
+                 ))
+                 .withColumn("tags", F.array(F.concat(F.lit("tag-"), (F.col("id") % 5).cast("string")),
+                                             F.concat(F.lit("tag-"), (F.col("id") % 7).cast("string"))))
+                 .withColumn("attributes", F.map_from_arrays(
+                     F.array(F.lit("k1"), F.lit("k2")),
+                     F.array(F.concat(F.lit("v-"), (F.col("id") % 3).cast("string")),
+                             F.concat(F.lit("v-"), (F.col("id") % 5).cast("string"))))))
+        batch.writeTo(table).append()
+
+    files_before = file_count(spark, table)
+    rows_before = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    print(f"[iceberg-clustering] Wrote {rows_before} rows across {files_before} data files (target: {BATCHES})")
+
+    print(f"[iceberg-clustering] CALL rewrite_data_files(strategy='sort', sort_order='{SORT_ORDER}')")
+    spark.sql(f"""
+        CALL spark_catalog.system.rewrite_data_files(
+          table => '{table}',
+          strategy => 'sort',
+          sort_order => '{SORT_ORDER}'
+        )
+    """).collect()
+    files_after = file_count(spark, table)
+
+    print(f"[iceberg-clustering] Files: {files_before} -> {files_after}")
+    assert files_after < files_before, \
+        f"Expected file count to decrease after clustering ({files_before} -> {files_after})"
+
+    rows = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    assert rows == rows_before, f"Row count changed during clustering: {rows_before} -> {rows}"
+    print(f"[iceberg-clustering] PASS — {rows} rows preserved, files compacted {files_before} -> {files_after}")
+
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/clustering-demo/quanton-hudi-clustering-demo.yaml
+++ b/examples/clustering-demo/quanton-hudi-clustering-demo.yaml
@@ -1,0 +1,193 @@
+# Quanton Hudi clustering demo
+#
+# Writes 100 rows with a complex (Struct / Array / Map / nested) schema to a
+# Hudi COW table laid out as many tiny files, then runs run_clustering with
+# sort-by columns. Asserts the file count decreased after clustering.
+#
+# Sets spark.quanton.clustering.accelerate=true so the sort + write inside
+# the clustering procedure runs through Quanton's native group writer.
+#
+# The script source is also available at examples/hudi_clustering_demo.py.
+#
+# Usage:
+#   kubectl apply -f examples/quanton-hudi-clustering-demo.yaml
+#   kubectl logs -f quanton-hudi-clustering-demo-driver
+#
+# Cleanup:
+#   kubectl delete -f examples/quanton-hudi-clustering-demo.yaml
+#   kubectl delete pvc quanton-hudi-clustering-demo-pvc
+#
+# Requires:
+#   - Quanton Operator installed (see README)
+#   - Internet access from pods (downloads hudi-spark3.5-bundle on first run)
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quanton-hudi-clustering-demo-script
+  namespace: default
+data:
+  hudi_clustering_demo.py: |
+    """hudi_clustering_demo.py — Hudi clustering demo (see examples/hudi_clustering_demo.py)."""
+    import os
+    import sys
+
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    SORT_COLUMNS = "region,ts"
+    ROWS = 100
+    EVENT_TYPES = [f"event_{i:02d}" for i in range(8)]
+    REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-south-1"]
+
+    def count_parquet_files(table_path):
+        n = 0
+        for root, dirs, files in os.walk(table_path):
+            dirs[:] = [d for d in dirs if not d.startswith(".hoodie")]
+            for f in files:
+                if f.endswith(".parquet"):
+                    n += 1
+        return n
+
+    def count_replacecommits(table_path):
+        # Hudi doesn't physically delete old files on clustering; the timeline
+        # adds a .replacecommit instead. Use that as the success signal.
+        timeline = os.path.join(table_path, ".hoodie")
+        if not os.path.isdir(timeline):
+            return 0
+        return sum(1 for f in os.listdir(timeline) if f.endswith(".replacecommit"))
+
+    output_dir = sys.argv[1].rstrip("/")
+    table_path = f"{output_dir}/events_hudi"
+    table_name = "events_hudi"
+
+    spark = (SparkSession.builder
+             .appName("HudiClusteringDemo")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config("spark.kryo.registrator", "org.apache.spark.HoodieSparkKryoRegistrar")
+             .config("spark.sql.extensions", "org.apache.spark.sql.hudi.HoodieSparkSessionExtension")
+             .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.hudi.catalog.HoodieCatalog")
+             .getOrCreate())
+    spark.sparkContext.setLogLevel("WARN")
+
+    print(f"[hudi-clustering] Generating {ROWS} rows with complex schema -> {table_path}")
+    df = (spark.range(0, ROWS)
+          .withColumn("ts", F.expr("from_unixtime(unix_timestamp(current_timestamp()) - cast(rand(42) * 86400 * 90 as bigint))").cast("timestamp"))
+          .withColumn("region", F.element_at(F.array(*[F.lit(r) for r in REGIONS]),
+                                             (F.col("id") % len(REGIONS) + 1).cast("int")))
+          .withColumn("customer_id", F.concat(F.lit("cust-"), F.lpad((F.col("id") % 50).cast("string"), 4, "0")))
+          .withColumn("amount", (F.rand(7) * 1000.0).cast("decimal(15,2)"))
+          .withColumn("event_type", F.element_at(F.array(*[F.lit(e) for e in EVENT_TYPES]),
+                                                 (F.col("id") % len(EVENT_TYPES) + 1).cast("int")))
+          .withColumn("address", F.struct(
+              F.concat(F.lit("street-"), (F.col("id") % 99).cast("string")).alias("street"),
+              F.concat(F.lit("city-"), (F.col("id") % 20).cast("string")).alias("city"),
+              F.lpad((F.col("id") % 99999).cast("string"), 5, "0").alias("zip"),
+          ))
+          .withColumn("tags", F.array(F.concat(F.lit("tag-"), (F.col("id") % 5).cast("string")),
+                                      F.concat(F.lit("tag-"), (F.col("id") % 7).cast("string"))))
+          .withColumn("attributes", F.map_from_arrays(
+              F.array(F.lit("k1"), F.lit("k2")),
+              F.array(F.concat(F.lit("v-"), (F.col("id") % 3).cast("string")),
+                      F.concat(F.lit("v-"), (F.col("id") % 5).cast("string"))))))
+
+    (df.repartition(50)
+       .write.format("hudi")
+       .option("hoodie.table.name", table_name)
+       .option("hoodie.datasource.write.recordkey.field", "id")
+       .option("hoodie.datasource.write.precombine.field", "ts")
+       .option("hoodie.datasource.write.operation", "bulk_insert")
+       .option("hoodie.parquet.max.file.size", "1024")
+       .option("hoodie.parquet.small.file.limit", "0")
+       .option("hoodie.clustering.inline", "false")
+       .option("hoodie.clustering.async.enabled", "false")
+       .option("hoodie.metadata.enable", "false")
+       .option("hoodie.parquet.compression.codec", "zstd")
+       .mode("overwrite")
+       .save(table_path))
+
+    files_before = count_parquet_files(table_path)
+    print(f"[hudi-clustering] Wrote table with {files_before} small parquet files")
+
+    spark.sql(f"CREATE TABLE IF NOT EXISTS {table_name} USING hudi LOCATION '{table_path}'")
+
+    print(f"[hudi-clustering] CALL run_clustering(order='{SORT_COLUMNS}', op='scheduleandexecute')")
+    spark.sql(f"CALL run_clustering(table => '{table_name}', order => '{SORT_COLUMNS}', op => 'scheduleandexecute')").collect()
+    files_after = count_parquet_files(table_path)
+    replacecommits = count_replacecommits(table_path)
+
+    print(f"[hudi-clustering] On-disk parquet files: {files_before} -> {files_after} (Hudi keeps old files; new ones + .replacecommit are added)")
+    print(f"[hudi-clustering] .replacecommit files in .hoodie/: {replacecommits}")
+    assert replacecommits >= 1, f"Expected at least one .replacecommit after clustering, got {replacecommits}"
+    rows = spark.sql(f"SELECT count(*) AS c FROM {table_name}").collect()[0]["c"]
+    assert rows == ROWS, f"Expected {ROWS} rows after clustering, got {rows}"
+    print(f"[hudi-clustering] PASS — {rows} rows preserved, {replacecommits} replacecommit(s) on timeline")
+    spark.stop()
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: quanton-hudi-clustering-demo-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: quantonsparkoperator.onehouse.ai/v1beta2
+kind: QuantonSparkApplication
+metadata:
+  name: quanton-hudi-clustering-demo
+  namespace: default
+spec:
+  sparkApplicationSpec:
+    type: Python
+    mode: cluster
+    image: "apache/spark:3.5.0"
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: "local:///mnt/scripts/hudi_clustering_demo.py"
+    arguments:
+      - "/data/hudi-clustering-demo"
+    sparkVersion: "3.5.0"
+    restartPolicy:
+      type: Never
+    sparkConf:
+      spark.jars.packages: "org.apache.hudi:hudi-spark3.5-bundle_2.12:0.15.0"
+      spark.jars.ivy: "/tmp/ivy"
+      spark.quanton.clustering.accelerate: "true"
+      spark.serializer: "org.apache.spark.serializer.KryoSerializer"
+      spark.kryo.registrator: "org.apache.spark.HoodieSparkKryoRegistrar"
+      spark.sql.extensions: "org.apache.spark.sql.hudi.HoodieSparkSessionExtension"
+      spark.sql.catalog.spark_catalog: "org.apache.spark.sql.hudi.catalog.HoodieCatalog"
+    volumes:
+      - name: scripts
+        configMap:
+          name: quanton-hudi-clustering-demo-script
+      - name: hudi-output
+        persistentVolumeClaim:
+          claimName: quanton-hudi-clustering-demo-pvc
+    driver:
+      cores: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      serviceAccount: spark-operator-spark
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: hudi-output
+          mountPath: /data/hudi-clustering-demo
+    executor:
+      cores: 1
+      instances: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: hudi-output
+          mountPath: /data/hudi-clustering-demo

--- a/examples/clustering-demo/quanton-iceberg-clustering-demo.yaml
+++ b/examples/clustering-demo/quanton-iceberg-clustering-demo.yaml
@@ -1,0 +1,180 @@
+# Quanton Iceberg clustering demo
+#
+# Writes 100 rows with a complex (Struct / Array / Map) schema to an Iceberg
+# table laid out as many small files (via 20 sequential INSERT batches), then
+# runs rewrite_data_files(strategy='sort') with sort-by columns. Asserts the
+# file count decreased after clustering.
+#
+# Sets spark.quanton.clustering.accelerate=true so the sort inside the
+# rewrite_data_files procedure runs through Quanton-native execution.
+#
+# The iceberg jars (iceberg-spark-runtime, iceberg-aws-bundle,
+# iceberg-spark-quanton) are pre-bundled in the Quanton image at
+# /opt/spark/user-jars/; we put them on the classpath via
+# spark.{driver,executor}.extraClassPath rather than spark.jars.packages,
+# which would pull a maven copy with mismatched shaded-parquet classes and
+# break with a ClassCastException.
+#
+# The script source is also available at examples/iceberg_clustering_demo.py.
+#
+# Usage:
+#   kubectl apply -f examples/quanton-iceberg-clustering-demo.yaml
+#   kubectl logs -f quanton-iceberg-clustering-demo-driver
+#
+# Cleanup:
+#   kubectl delete -f examples/quanton-iceberg-clustering-demo.yaml
+#   kubectl delete pvc quanton-iceberg-clustering-demo-pvc
+#
+# Requires:
+#   - Quanton Operator installed (see README)
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quanton-iceberg-clustering-demo-script
+  namespace: default
+data:
+  iceberg_clustering_demo.py: |
+    """iceberg_clustering_demo.py — Iceberg clustering demo (see examples/iceberg_clustering_demo.py)."""
+    import sys
+
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    SORT_ORDER = "region ASC NULLS LAST, ts ASC NULLS LAST"
+    ROWS_PER_BATCH = 5
+    BATCHES = 20
+    EVENT_TYPES = [f"event_{i:02d}" for i in range(8)]
+    REGIONS = ["us-east-1", "us-west-2", "eu-west-1", "ap-south-1"]
+
+    def file_count(spark, table):
+        return int(spark.sql(f"SELECT count(*) AS c FROM {table}.files").collect()[0]["c"])
+
+    warehouse = sys.argv[1].rstrip("/")
+    table = "default.events_iceberg"
+
+    spark = (SparkSession.builder
+             .appName("IcebergClusteringDemo")
+             .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+             .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", warehouse)
+             .getOrCreate())
+    spark.sparkContext.setLogLevel("WARN")
+
+    print(f"[iceberg-clustering] Creating {table} in {warehouse}")
+    spark.sql(f"DROP TABLE IF EXISTS {table}")
+    spark.sql(f"""
+      CREATE TABLE {table} (
+        id BIGINT, ts TIMESTAMP, region STRING, customer_id STRING,
+        amount DECIMAL(15,2), event_type STRING,
+        address STRUCT<street: STRING, city: STRING, zip: STRING>,
+        tags ARRAY<STRING>,
+        attributes MAP<STRING, STRING>
+      )
+      USING iceberg
+      TBLPROPERTIES ('write.parquet.compression-codec' = 'zstd')
+    """)
+
+    for b in range(BATCHES):
+        batch = (spark.range(b * ROWS_PER_BATCH, (b + 1) * ROWS_PER_BATCH)
+                 .withColumn("ts", F.expr("from_unixtime(unix_timestamp(current_timestamp()) - cast(rand(42) * 86400 * 90 as bigint))").cast("timestamp"))
+                 .withColumn("region", F.element_at(F.array(*[F.lit(r) for r in REGIONS]),
+                                                    (F.col("id") % len(REGIONS) + 1).cast("int")))
+                 .withColumn("customer_id", F.concat(F.lit("cust-"), F.lpad((F.col("id") % 50).cast("string"), 4, "0")))
+                 .withColumn("amount", (F.rand(7) * 1000.0).cast("decimal(15,2)"))
+                 .withColumn("event_type", F.element_at(F.array(*[F.lit(e) for e in EVENT_TYPES]),
+                                                        (F.col("id") % len(EVENT_TYPES) + 1).cast("int")))
+                 .withColumn("address", F.struct(
+                     F.concat(F.lit("street-"), (F.col("id") % 99).cast("string")).alias("street"),
+                     F.concat(F.lit("city-"), (F.col("id") % 20).cast("string")).alias("city"),
+                     F.lpad((F.col("id") % 99999).cast("string"), 5, "0").alias("zip"),
+                 ))
+                 .withColumn("tags", F.array(F.concat(F.lit("tag-"), (F.col("id") % 5).cast("string")),
+                                             F.concat(F.lit("tag-"), (F.col("id") % 7).cast("string"))))
+                 .withColumn("attributes", F.map_from_arrays(
+                     F.array(F.lit("k1"), F.lit("k2")),
+                     F.array(F.concat(F.lit("v-"), (F.col("id") % 3).cast("string")),
+                             F.concat(F.lit("v-"), (F.col("id") % 5).cast("string"))))))
+        batch.writeTo(table).append()
+
+    files_before = file_count(spark, table)
+    rows_before = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    print(f"[iceberg-clustering] Wrote {rows_before} rows across {files_before} data files")
+
+    print(f"[iceberg-clustering] CALL rewrite_data_files(strategy='sort', sort_order='{SORT_ORDER}')")
+    spark.sql(f"CALL spark_catalog.system.rewrite_data_files(table => '{table}', strategy => 'sort', sort_order => '{SORT_ORDER}')").collect()
+    files_after = file_count(spark, table)
+
+    print(f"[iceberg-clustering] Files: {files_before} -> {files_after}")
+    assert files_after < files_before, f"Expected file count to decrease ({files_before} -> {files_after})"
+    rows = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    assert rows == rows_before, f"Row count changed: {rows_before} -> {rows}"
+    print(f"[iceberg-clustering] PASS — {rows} rows preserved, files compacted {files_before} -> {files_after}")
+    spark.stop()
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: quanton-iceberg-clustering-demo-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: quantonsparkoperator.onehouse.ai/v1beta2
+kind: QuantonSparkApplication
+metadata:
+  name: quanton-iceberg-clustering-demo
+  namespace: default
+spec:
+  sparkApplicationSpec:
+    type: Python
+    mode: cluster
+    image: "apache/spark:3.5.0"
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: "local:///mnt/scripts/iceberg_clustering_demo.py"
+    arguments:
+      - "/data/iceberg-clustering-demo"
+    sparkVersion: "3.5.0"
+    restartPolicy:
+      type: Never
+    sparkConf:
+      # Bundled iceberg jars on the Quanton image — see header comment.
+      spark.driver.extraClassPath: "/opt/spark/user-jars/iceberg-spark-runtime.jar:/opt/spark/user-jars/iceberg-aws-bundle.jar:/opt/spark/user-jars/iceberg-spark-quanton.jar"
+      spark.executor.extraClassPath: "/opt/spark/user-jars/iceberg-spark-runtime.jar:/opt/spark/user-jars/iceberg-aws-bundle.jar:/opt/spark/user-jars/iceberg-spark-quanton.jar"
+      spark.jars.ivy: "/tmp/ivy"
+      spark.quanton.clustering.accelerate: "true"
+    volumes:
+      - name: scripts
+        configMap:
+          name: quanton-iceberg-clustering-demo-script
+      - name: iceberg-output
+        persistentVolumeClaim:
+          claimName: quanton-iceberg-clustering-demo-pvc
+    driver:
+      cores: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      serviceAccount: spark-operator-spark
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: iceberg-output
+          mountPath: /data/iceberg-clustering-demo
+    executor:
+      cores: 1
+      instances: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: iceberg-output
+          mountPath: /data/iceberg-clustering-demo


### PR DESCRIPTION
## Summary

Adds `examples/clustering-demo/` with two self-contained clustering demos plus a [Claude Code skill](.claude/skills/run-clustering/SKILL.md) that triggers them via `/run-clustering`.

- `examples/clustering-demo/quanton-hudi-clustering-demo.yaml` + `hudi_clustering_demo.py`
- `examples/clustering-demo/quanton-iceberg-clustering-demo.yaml` + `iceberg_clustering_demo.py`
- `examples/clustering-demo/README.md` — quick-start + caveats
- `.claude/skills/run-clustering/SKILL.md` — interactive runner

Each demo writes 100 rows with a complex schema (Struct / Array / Map / nested), forces a many-tiny-files layout, then runs the native clustering procedure with sort-by columns and `spark.quanton.clustering.accelerate=true`:

- Hudi: `CALL run_clustering(order='region,ts', op='scheduleandexecute')`
- Iceberg: `CALL rewrite_data_files(strategy='sort', sort_order='region ASC, ts ASC')`

## Test plan

- [x] Iceberg demo: 40 → 1 files, 100 rows preserved, `PASS` on minikube
- [x] Hudi demo: `.replacecommit` on timeline, 100 rows preserved, `PASS` on minikube