### PR TITLE
Fix Onehouse console link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The operator provides a seamless migration path — submit your existing Spark j
 
 ## Quick Start
 
-1. Obtain your `onehouse-values.yaml` from the [Onehouse console](https://www.cloud.onehouse.ai).
+1. Obtain your `onehouse-values.yaml` from the [Onehouse console](https://cloud.onehouse.ai).
 2. Install the operator:
 
 ```bash
@@ -127,7 +127,7 @@ Then use either skill:
 | `/run-tpcds-benchmark`   | Runs the TPC-DS read benchmark (99 queries on Parquet) comparing OSS Spark vs Quanton. Asks you for scale factor and configuration, gives live progress updates, and produces a per-query comparison table and chart. |
 
 
-Both skills check prerequisites, handle errors, and give you live progress updates as jobs run on your local minikube cluster. You will need `onehouse-values.yaml` (from the [Onehouse console](https://www.cloud.onehouse.ai)) to install the Quanton Operator.
+Both skills check prerequisites, handle errors, and give you live progress updates as jobs run on your local minikube cluster. You will need `onehouse-values.yaml` (from the [Onehouse console](https://cloud.onehouse.ai)) to install the Quanton Operator.
 
 ## Benchmarks
 


### PR DESCRIPTION
## Summary
- The README linked to `https://www.cloud.onehouse.ai` in two places (Quick Start and Claude Skills sections), but the actual console is at `https://cloud.onehouse.ai` (no `www` subdomain).
- Both occurrences updated to the correct URL.

## Test plan
- [ ] Click both links in the rendered README and confirm they load the Onehouse console