### PR TITLE
Add Hudi and Iceberg MERGE INTO demos

### DIFF
--- a/examples/merge-into-demo/README.md
+++ b/examples/merge-into-demo/README.md
@@ -1,0 +1,65 @@
+# Quanton MERGE INTO Demo
+
+End-to-end `MERGE INTO` demos for Apache Hudi and Apache Iceberg, runnable on minikube via
+QuantonSparkApplication.
+
+Each demo creates a `customers` table, inserts 10 rows, then runs `MERGE INTO ... USING source ...`
+with 3 updates and 3 inserts. Verifies the final state (`10 -> 13 rows, 3 'vip'`).
+
+| Format  | Manifest                                                                     | Script                                                          |
+|---------|------------------------------------------------------------------------------|-----------------------------------------------------------------|
+| Hudi    | [`quanton-hudi-merge-into-demo.yaml`](quanton-hudi-merge-into-demo.yaml)     | [`hudi_merge_into_demo.py`](hudi_merge_into_demo.py)            |
+| Iceberg | [`quanton-iceberg-merge-into-demo.yaml`](quanton-iceberg-merge-into-demo.yaml) | [`iceberg_merge_into_demo.py`](iceberg_merge_into_demo.py)      |
+
+## Prerequisites
+
+- minikube running with at least 4 CPUs / 8 GB RAM
+- Spark Operator and Quanton Operator installed and `Running`
+  (see [`../../README.md`](../../README.md))
+
+## Run
+
+### Hudi
+
+```bash
+kubectl apply -f quanton-hudi-merge-into-demo.yaml
+kubectl logs -f quanton-hudi-merge-into-demo-driver -n default
+```
+
+Expected tail:
+
+```
+[hudi-merge] After MERGE: 13 rows, 3 'vip'
+[hudi-merge] PASS — 10 -> 13 rows, 3 updated to 'vip'
+```
+
+### Iceberg
+
+```bash
+kubectl apply -f quanton-iceberg-merge-into-demo.yaml
+kubectl logs -f quanton-iceberg-merge-into-demo-driver -n default
+```
+
+Expected tail:
+
+```
+[iceberg-merge] After MERGE: 13 rows, 3 'vip'
+[iceberg-merge] PASS — 10 -> 13 rows, 3 updated to 'vip'
+```
+
+## Cleanup
+
+```bash
+kubectl delete -f quanton-hudi-merge-into-demo.yaml
+kubectl delete -f quanton-iceberg-merge-into-demo.yaml
+kubectl delete pvc quanton-hudi-merge-into-demo-pvc quanton-iceberg-merge-into-demo-pvc -n default
+```
+
+## Files
+
+| File                                     | Role                                                                                                                                          |
+|------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `quanton-hudi-merge-into-demo.yaml`      | ConfigMap (inline `hudi_merge_into_demo.py`) + 2 Gi PVC + QuantonSparkApplication. Hudi COW table; pulls `hudi-spark3.5-bundle` from Maven.   |
+| `quanton-iceberg-merge-into-demo.yaml`   | Same shape for Iceberg. Uses Hadoop catalog on the PVC; iceberg jars are pre-bundled in the Quanton image at `/opt/spark/user-jars/`.         |
+| `hudi_merge_into_demo.py`                | Standalone source — CREATE Hudi COW table, INSERT 10 rows, MERGE INTO with 3 updates + 3 inserts, assert `10 -> 13` rows and 3 `'vip'`.       |
+| `iceberg_merge_into_demo.py`             | Standalone source — same workflow for Iceberg (Hadoop catalog).                                                                               |

--- a/examples/merge-into-demo/hudi_merge_into_demo.py
+++ b/examples/merge-into-demo/hudi_merge_into_demo.py
@@ -1,0 +1,104 @@
+"""
+hudi_merge_into_demo.py — Hudi CREATE / INSERT / MERGE INTO demo (COW).
+
+End-to-end MERGE INTO demo:
+  1. CREATE TABLE customers (Hudi COW, primary key = id, precombine = ts).
+  2. INSERT 10 starting rows.
+  3. Build a source DataFrame with 6 rows: 3 updates + 3 inserts.
+  4. MERGE INTO ... WHEN MATCHED ... WHEN NOT MATCHED ... using SQL.
+  5. Verify the result (10 -> 13 rows, 3 updated to 'vip').
+
+Usage:
+  spark-submit hudi_merge_into_demo.py <warehouseDir>
+"""
+
+import sys
+
+from pyspark.sql import SparkSession, Row
+
+
+warehouse = sys.argv[1].rstrip("/")
+table_path = f"{warehouse}/customers"
+table = "default.customers"
+
+spark = (SparkSession.builder
+         .appName("HudiMergeIntoDemo")
+         .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+         .config("spark.kryo.registrator", "org.apache.spark.HoodieSparkKryoRegistrar")
+         .config("spark.sql.extensions", "org.apache.spark.sql.hudi.HoodieSparkSessionExtension")
+         .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.hudi.catalog.HoodieCatalog")
+         .getOrCreate())
+spark.sparkContext.setLogLevel("WARN")
+
+print(f"[hudi-merge] Creating {table} at {table_path}")
+spark.sql(f"DROP TABLE IF EXISTS {table}")
+spark.sql(f"""
+  CREATE TABLE {table} (
+    id      BIGINT,
+    ts      BIGINT,
+    name    STRING,
+    region  STRING,
+    amount  DECIMAL(15,2),
+    status  STRING
+  )
+  USING hudi
+  TBLPROPERTIES (
+    type             = 'cow',
+    primaryKey       = 'id',
+    preCombineField  = 'ts'
+  )
+  LOCATION '{table_path}'
+""")
+
+print(f"[hudi-merge] INSERT 10 initial rows")
+spark.sql(f"""
+  INSERT INTO {table} VALUES
+    (1,  1, 'Alice',   'us-east-1',  100.00, 'active'),
+    (2,  1, 'Bob',     'us-west-2',  250.50, 'active'),
+    (3,  1, 'Carol',   'eu-west-1',   75.25, 'active'),
+    (4,  1, 'Dave',    'ap-south-1', 500.00, 'active'),
+    (5,  1, 'Eve',     'us-east-1',  150.75, 'active'),
+    (6,  1, 'Frank',   'us-west-2',  300.00, 'active'),
+    (7,  1, 'Grace',   'eu-west-1',  220.00, 'active'),
+    (8,  1, 'Heidi',   'ap-south-1', 410.00, 'active'),
+    (9,  1, 'Ivan',    'us-east-1',  180.00, 'active'),
+    (10, 1, 'Judy',    'us-west-2',  275.00, 'active')
+""")
+rows_before = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+print(f"[hudi-merge] After INSERT: {rows_before} rows")
+
+# Source dataset: 3 updates (id 2, 5, 8) and 3 new inserts (id 11, 12, 13)
+# Bump ts so updates win precombine.
+source = spark.createDataFrame([
+    Row(id=2,  ts=2, name='Bob',    region='us-west-2',  amount=999.99, status='vip'),
+    Row(id=5,  ts=2, name='Eve',    region='us-east-1',  amount=888.88, status='vip'),
+    Row(id=8,  ts=2, name='Heidi',  region='ap-south-1', amount=777.77, status='vip'),
+    Row(id=11, ts=2, name='Kevin',  region='us-east-1',  amount=120.00, status='active'),
+    Row(id=12, ts=2, name='Laura',  region='us-west-2',  amount=140.00, status='active'),
+    Row(id=13, ts=2, name='Mallory',region='eu-west-1',  amount=160.00, status='active'),
+])
+source.createOrReplaceTempView("source_updates")
+
+print(f"[hudi-merge] MERGE INTO {table} (3 updates + 3 inserts)")
+spark.sql(f"""
+  MERGE INTO {table} t
+  USING source_updates s
+  ON t.id = s.id
+  WHEN MATCHED THEN UPDATE SET
+    t.ts     = s.ts,
+    t.amount = s.amount,
+    t.status = s.status
+  WHEN NOT MATCHED THEN INSERT (id, ts, name, region, amount, status)
+    VALUES (s.id, s.ts, s.name, s.region, s.amount, s.status)
+""")
+
+rows_after = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+vip_count = int(spark.sql(f"SELECT count(*) AS c FROM {table} WHERE status = 'vip'").collect()[0]["c"])
+print(f"[hudi-merge] After MERGE: {rows_after} rows, {vip_count} 'vip'")
+print(f"[hudi-merge] Final table:")
+spark.sql(f"SELECT id, ts, name, region, amount, status FROM {table} ORDER BY id").show(50, truncate=False)
+
+assert rows_after == 13, f"Expected 13 rows after merge, got {rows_after}"
+assert vip_count == 3,   f"Expected 3 vip rows after merge, got {vip_count}"
+print(f"[hudi-merge] PASS — {rows_before} -> {rows_after} rows, 3 updated to 'vip'")
+spark.stop()

--- a/examples/merge-into-demo/iceberg_merge_into_demo.py
+++ b/examples/merge-into-demo/iceberg_merge_into_demo.py
@@ -1,0 +1,102 @@
+"""
+iceberg_merge_into_demo.py — Iceberg CREATE / INSERT / MERGE INTO demo on a Hadoop catalog.
+
+End-to-end MERGE INTO demo:
+  1. CREATE TABLE customers (Iceberg, Hadoop catalog).
+  2. INSERT 10 starting rows.
+  3. Build a source DataFrame with 6 rows: 3 updates + 3 inserts.
+  4. MERGE INTO ... WHEN MATCHED ... WHEN NOT MATCHED ... using SQL.
+  5. Verify the result (10 -> 13 rows, 3 updated to 'vip').
+
+Usage:
+  spark-submit iceberg_merge_into_demo.py <warehouseDir>
+"""
+
+import sys
+
+from pyspark.sql import SparkSession, Row
+
+
+warehouse = sys.argv[1].rstrip("/")
+table = "default.customers"
+
+spark = (SparkSession.builder
+         .appName("IcebergMergeIntoDemo")
+         .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+         .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+         .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+         .config("spark.sql.catalog.spark_catalog.warehouse", warehouse)
+         .getOrCreate())
+spark.sparkContext.setLogLevel("WARN")
+
+print(f"[iceberg-merge] Creating {table} in {warehouse}")
+spark.sql(f"DROP TABLE IF EXISTS {table}")
+spark.sql(f"""
+  CREATE TABLE {table} (
+    id BIGINT,
+    name STRING,
+    region STRING,
+    amount DECIMAL(15,2),
+    status STRING
+  )
+  USING iceberg
+  TBLPROPERTIES (
+    'write.parquet.compression-codec' = 'zstd',
+    'format-version'    = '2',
+    'write.merge.mode'  = 'copy-on-write',
+    'write.update.mode' = 'copy-on-write',
+    'write.delete.mode' = 'copy-on-write'
+  )
+""")
+spark.sql(f"ALTER TABLE {table} SET TBLPROPERTIES ('write.distribution-mode' = 'hash')")
+
+print(f"[iceberg-merge] INSERT 10 initial rows")
+spark.sql(f"""
+  INSERT INTO {table} VALUES
+    (1,  'Alice',   'us-east-1',  100.00, 'active'),
+    (2,  'Bob',     'us-west-2',  250.50, 'active'),
+    (3,  'Carol',   'eu-west-1',   75.25, 'active'),
+    (4,  'Dave',    'ap-south-1', 500.00, 'active'),
+    (5,  'Eve',     'us-east-1',  150.75, 'active'),
+    (6,  'Frank',   'us-west-2',  300.00, 'active'),
+    (7,  'Grace',   'eu-west-1',  220.00, 'active'),
+    (8,  'Heidi',   'ap-south-1', 410.00, 'active'),
+    (9,  'Ivan',    'us-east-1',  180.00, 'active'),
+    (10, 'Judy',    'us-west-2',  275.00, 'active')
+""")
+rows_before = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+print(f"[iceberg-merge] After INSERT: {rows_before} rows")
+
+# Source dataset: 3 updates (id 2, 5, 8) and 3 new inserts (id 11, 12, 13)
+source = spark.createDataFrame([
+    Row(id=2,  name='Bob',    region='us-west-2',  amount=999.99, status='vip'),
+    Row(id=5,  name='Eve',    region='us-east-1',  amount=888.88, status='vip'),
+    Row(id=8,  name='Heidi',  region='ap-south-1', amount=777.77, status='vip'),
+    Row(id=11, name='Kevin',  region='us-east-1',  amount=120.00, status='active'),
+    Row(id=12, name='Laura',  region='us-west-2',  amount=140.00, status='active'),
+    Row(id=13, name='Mallory',region='eu-west-1',  amount=160.00, status='active'),
+])
+source.createOrReplaceTempView("source_updates")
+
+print(f"[iceberg-merge] MERGE INTO {table} (3 updates + 3 inserts)")
+spark.sql(f"""
+  MERGE INTO {table} t
+  USING source_updates s
+  ON t.id = s.id
+  WHEN MATCHED THEN UPDATE SET
+    t.amount = s.amount,
+    t.status = s.status
+  WHEN NOT MATCHED THEN INSERT (id, name, region, amount, status)
+    VALUES (s.id, s.name, s.region, s.amount, s.status)
+""")
+
+rows_after = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+vip_count = int(spark.sql(f"SELECT count(*) AS c FROM {table} WHERE status = 'vip'").collect()[0]["c"])
+print(f"[iceberg-merge] After MERGE: {rows_after} rows, {vip_count} 'vip'")
+print(f"[iceberg-merge] Final table:")
+spark.sql(f"SELECT * FROM {table} ORDER BY id").show(50, truncate=False)
+
+assert rows_after == 13, f"Expected 13 rows after merge, got {rows_after}"
+assert vip_count == 3,   f"Expected 3 vip rows after merge, got {vip_count}"
+print(f"[iceberg-merge] PASS — {rows_before} -> {rows_after} rows, 3 updated to 'vip'")
+spark.stop()

--- a/examples/merge-into-demo/quanton-hudi-merge-into-demo.yaml
+++ b/examples/merge-into-demo/quanton-hudi-merge-into-demo.yaml
@@ -1,0 +1,185 @@
+# Quanton Hudi MERGE INTO demo
+#
+# End-to-end Hudi (COW) demo:
+#   1. CREATE TABLE customers (Hudi COW, primary key = id, precombine = ts).
+#   2. INSERT 10 starting rows.
+#   3. Build a source DataFrame with 6 rows: 3 updates + 3 inserts.
+#   4. MERGE INTO ... WHEN MATCHED ... WHEN NOT MATCHED ... using SQL.
+#   5. Verify the result (10 -> 13 rows, 3 updated to 'vip').
+#
+# The script source is also available at examples/merge-into-demo/hudi_merge_into_demo.py.
+#
+# Usage:
+#   kubectl apply -f examples/merge-into-demo/quanton-hudi-merge-into-demo.yaml
+#   kubectl logs -f quanton-hudi-merge-into-demo-driver
+#
+# Cleanup:
+#   kubectl delete -f examples/merge-into-demo/quanton-hudi-merge-into-demo.yaml
+#   kubectl delete pvc quanton-hudi-merge-into-demo-pvc
+#
+# Requires:
+#   - Quanton Operator installed (see README)
+#   - Internet access from pods (downloads hudi-spark3.5-bundle on first run)
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quanton-hudi-merge-into-demo-script
+  namespace: default
+data:
+  hudi_merge_into_demo.py: |
+    """hudi_merge_into_demo.py — Hudi CREATE / INSERT / MERGE INTO demo (see examples/merge-into-demo/hudi_merge_into_demo.py)."""
+    import sys
+
+    from pyspark.sql import SparkSession, Row
+
+    warehouse = sys.argv[1].rstrip("/")
+    table_path = f"{warehouse}/customers"
+    table = "default.customers"
+
+    spark = (SparkSession.builder
+             .appName("HudiMergeIntoDemo")
+             .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+             .config("spark.kryo.registrator", "org.apache.spark.HoodieSparkKryoRegistrar")
+             .config("spark.sql.extensions", "org.apache.spark.sql.hudi.HoodieSparkSessionExtension")
+             .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.hudi.catalog.HoodieCatalog")
+             .getOrCreate())
+    spark.sparkContext.setLogLevel("WARN")
+
+    print(f"[hudi-merge] Creating {table} at {table_path}")
+    spark.sql(f"DROP TABLE IF EXISTS {table}")
+    spark.sql(f"""
+      CREATE TABLE {table} (
+        id      BIGINT,
+        ts      BIGINT,
+        name    STRING,
+        region  STRING,
+        amount  DECIMAL(15,2),
+        status  STRING
+      )
+      USING hudi
+      TBLPROPERTIES (
+        type             = 'cow',
+        primaryKey       = 'id',
+        preCombineField  = 'ts'
+      )
+      LOCATION '{table_path}'
+    """)
+
+    print(f"[hudi-merge] INSERT 10 initial rows")
+    spark.sql(f"""
+      INSERT INTO {table} VALUES
+        (1,  1, 'Alice',   'us-east-1',  100.00, 'active'),
+        (2,  1, 'Bob',     'us-west-2',  250.50, 'active'),
+        (3,  1, 'Carol',   'eu-west-1',   75.25, 'active'),
+        (4,  1, 'Dave',    'ap-south-1', 500.00, 'active'),
+        (5,  1, 'Eve',     'us-east-1',  150.75, 'active'),
+        (6,  1, 'Frank',   'us-west-2',  300.00, 'active'),
+        (7,  1, 'Grace',   'eu-west-1',  220.00, 'active'),
+        (8,  1, 'Heidi',   'ap-south-1', 410.00, 'active'),
+        (9,  1, 'Ivan',    'us-east-1',  180.00, 'active'),
+        (10, 1, 'Judy',    'us-west-2',  275.00, 'active')
+    """)
+    rows_before = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    print(f"[hudi-merge] After INSERT: {rows_before} rows")
+
+    source = spark.createDataFrame([
+        Row(id=2,  ts=2, name='Bob',    region='us-west-2',  amount=999.99, status='vip'),
+        Row(id=5,  ts=2, name='Eve',    region='us-east-1',  amount=888.88, status='vip'),
+        Row(id=8,  ts=2, name='Heidi',  region='ap-south-1', amount=777.77, status='vip'),
+        Row(id=11, ts=2, name='Kevin',  region='us-east-1',  amount=120.00, status='active'),
+        Row(id=12, ts=2, name='Laura',  region='us-west-2',  amount=140.00, status='active'),
+        Row(id=13, ts=2, name='Mallory',region='eu-west-1',  amount=160.00, status='active'),
+    ])
+    source.createOrReplaceTempView("source_updates")
+
+    print(f"[hudi-merge] MERGE INTO {table} (3 updates + 3 inserts)")
+    spark.sql(f"""
+      MERGE INTO {table} t
+      USING source_updates s
+      ON t.id = s.id
+      WHEN MATCHED THEN UPDATE SET
+        t.ts     = s.ts,
+        t.amount = s.amount,
+        t.status = s.status
+      WHEN NOT MATCHED THEN INSERT (id, ts, name, region, amount, status)
+        VALUES (s.id, s.ts, s.name, s.region, s.amount, s.status)
+    """)
+
+    rows_after = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    vip_count = int(spark.sql(f"SELECT count(*) AS c FROM {table} WHERE status = 'vip'").collect()[0]["c"])
+    print(f"[hudi-merge] After MERGE: {rows_after} rows, {vip_count} 'vip'")
+    print(f"[hudi-merge] Final table:")
+    spark.sql(f"SELECT id, ts, name, region, amount, status FROM {table} ORDER BY id").show(50, truncate=False)
+
+    assert rows_after == 13, f"Expected 13 rows after merge, got {rows_after}"
+    assert vip_count == 3,   f"Expected 3 vip rows after merge, got {vip_count}"
+    print(f"[hudi-merge] PASS — {rows_before} -> {rows_after} rows, 3 updated to 'vip'")
+    spark.stop()
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: quanton-hudi-merge-into-demo-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: quantonsparkoperator.onehouse.ai/v1beta2
+kind: QuantonSparkApplication
+metadata:
+  name: quanton-hudi-merge-into-demo
+  namespace: default
+spec:
+  sparkApplicationSpec:
+    type: Python
+    mode: cluster
+    image: "apache/spark:3.5.0"
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: "local:///mnt/scripts/hudi_merge_into_demo.py"
+    arguments:
+      - "/data/hudi-merge-into-demo"
+    sparkVersion: "3.5.0"
+    restartPolicy:
+      type: Never
+    sparkConf:
+      spark.jars.packages: "org.apache.hudi:hudi-spark3.5-bundle_2.12:0.15.0"
+      spark.jars.ivy: "/tmp/ivy"
+      spark.serializer: "org.apache.spark.serializer.KryoSerializer"
+      spark.kryo.registrator: "org.apache.spark.HoodieSparkKryoRegistrar"
+      spark.sql.extensions: "org.apache.spark.sql.hudi.HoodieSparkSessionExtension"
+      spark.sql.catalog.spark_catalog: "org.apache.spark.sql.hudi.catalog.HoodieCatalog"
+    volumes:
+      - name: scripts
+        configMap:
+          name: quanton-hudi-merge-into-demo-script
+      - name: hudi-output
+        persistentVolumeClaim:
+          claimName: quanton-hudi-merge-into-demo-pvc
+    driver:
+      cores: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      serviceAccount: spark-operator-spark
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: hudi-output
+          mountPath: /data/hudi-merge-into-demo
+    executor:
+      cores: 1
+      instances: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: hudi-output
+          mountPath: /data/hudi-merge-into-demo

--- a/examples/merge-into-demo/quanton-iceberg-merge-into-demo.yaml
+++ b/examples/merge-into-demo/quanton-iceberg-merge-into-demo.yaml
@@ -1,0 +1,183 @@
+# Quanton Iceberg MERGE INTO demo
+#
+# End-to-end Iceberg demo on a Hadoop catalog:
+#   1. CREATE TABLE customers (Iceberg).
+#   2. INSERT 10 starting rows.
+#   3. Build a source DataFrame with 6 rows: 3 updates + 3 inserts.
+#   4. MERGE INTO ... WHEN MATCHED ... WHEN NOT MATCHED ... using SQL.
+#   5. Verify the result (10 -> 13 rows, 3 updated to 'vip').
+#
+# No Glue / S3 needed — the warehouse is a Hadoop-catalog directory on a PVC.
+#
+# The script source is also available at examples/merge-into-demo/iceberg_merge_into_demo.py.
+#
+# Usage:
+#   kubectl apply -f examples/merge-into-demo/quanton-iceberg-merge-into-demo.yaml
+#   kubectl logs -f quanton-iceberg-merge-into-demo-driver
+#
+# Cleanup:
+#   kubectl delete -f examples/merge-into-demo/quanton-iceberg-merge-into-demo.yaml
+#   kubectl delete pvc quanton-iceberg-merge-into-demo-pvc
+#
+# Requires:
+#   - Quanton Operator installed (see README)
+#
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quanton-iceberg-merge-into-demo-script
+  namespace: default
+data:
+  iceberg_merge_into_demo.py: |
+    """iceberg_merge_into_demo.py — Iceberg CREATE / INSERT / MERGE INTO demo (see examples/merge-into-demo/iceberg_merge_into_demo.py)."""
+    import sys
+
+    from pyspark.sql import SparkSession, Row
+
+    warehouse = sys.argv[1].rstrip("/")
+    table = "default.customers"
+
+    spark = (SparkSession.builder
+             .appName("IcebergMergeIntoDemo")
+             .config("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions")
+             .config("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+             .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+             .config("spark.sql.catalog.spark_catalog.warehouse", warehouse)
+             .getOrCreate())
+    spark.sparkContext.setLogLevel("WARN")
+
+    print(f"[iceberg-merge] Creating {table} in {warehouse}")
+    spark.sql(f"DROP TABLE IF EXISTS {table}")
+    spark.sql(f"""
+      CREATE TABLE {table} (
+        id BIGINT,
+        name STRING,
+        region STRING,
+        amount DECIMAL(15,2),
+        status STRING
+      )
+      USING iceberg
+      TBLPROPERTIES (
+        'write.parquet.compression-codec' = 'zstd',
+        'format-version'    = '2',
+        'write.merge.mode'  = 'copy-on-write',
+        'write.update.mode' = 'copy-on-write',
+        'write.delete.mode' = 'copy-on-write'
+      )
+    """)
+    spark.sql(f"ALTER TABLE {table} SET TBLPROPERTIES ('write.distribution-mode' = 'hash')")
+
+    print(f"[iceberg-merge] INSERT 10 initial rows")
+    spark.sql(f"""
+      INSERT INTO {table} VALUES
+        (1,  'Alice',   'us-east-1',  100.00, 'active'),
+        (2,  'Bob',     'us-west-2',  250.50, 'active'),
+        (3,  'Carol',   'eu-west-1',   75.25, 'active'),
+        (4,  'Dave',    'ap-south-1', 500.00, 'active'),
+        (5,  'Eve',     'us-east-1',  150.75, 'active'),
+        (6,  'Frank',   'us-west-2',  300.00, 'active'),
+        (7,  'Grace',   'eu-west-1',  220.00, 'active'),
+        (8,  'Heidi',   'ap-south-1', 410.00, 'active'),
+        (9,  'Ivan',    'us-east-1',  180.00, 'active'),
+        (10, 'Judy',    'us-west-2',  275.00, 'active')
+    """)
+    rows_before = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    print(f"[iceberg-merge] After INSERT: {rows_before} rows")
+
+    source = spark.createDataFrame([
+        Row(id=2,  name='Bob',    region='us-west-2',  amount=999.99, status='vip'),
+        Row(id=5,  name='Eve',    region='us-east-1',  amount=888.88, status='vip'),
+        Row(id=8,  name='Heidi',  region='ap-south-1', amount=777.77, status='vip'),
+        Row(id=11, name='Kevin',  region='us-east-1',  amount=120.00, status='active'),
+        Row(id=12, name='Laura',  region='us-west-2',  amount=140.00, status='active'),
+        Row(id=13, name='Mallory',region='eu-west-1',  amount=160.00, status='active'),
+    ])
+    source.createOrReplaceTempView("source_updates")
+
+    print(f"[iceberg-merge] MERGE INTO {table} (3 updates + 3 inserts)")
+    spark.sql(f"""
+      MERGE INTO {table} t
+      USING source_updates s
+      ON t.id = s.id
+      WHEN MATCHED THEN UPDATE SET
+        t.amount = s.amount,
+        t.status = s.status
+      WHEN NOT MATCHED THEN INSERT (id, name, region, amount, status)
+        VALUES (s.id, s.name, s.region, s.amount, s.status)
+    """)
+
+    rows_after = int(spark.sql(f"SELECT count(*) AS c FROM {table}").collect()[0]["c"])
+    vip_count = int(spark.sql(f"SELECT count(*) AS c FROM {table} WHERE status = 'vip'").collect()[0]["c"])
+    print(f"[iceberg-merge] After MERGE: {rows_after} rows, {vip_count} 'vip'")
+    print(f"[iceberg-merge] Final table:")
+    spark.sql(f"SELECT * FROM {table} ORDER BY id").show(50, truncate=False)
+
+    assert rows_after == 13, f"Expected 13 rows after merge, got {rows_after}"
+    assert vip_count == 3,   f"Expected 3 vip rows after merge, got {vip_count}"
+    print(f"[iceberg-merge] PASS — {rows_before} -> {rows_after} rows, 3 updated to 'vip'")
+    spark.stop()
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: quanton-iceberg-merge-into-demo-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: quantonsparkoperator.onehouse.ai/v1beta2
+kind: QuantonSparkApplication
+metadata:
+  name: quanton-iceberg-merge-into-demo
+  namespace: default
+spec:
+  sparkApplicationSpec:
+    type: Python
+    mode: cluster
+    image: "apache/spark:3.5.0"
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: "local:///mnt/scripts/iceberg_merge_into_demo.py"
+    arguments:
+      - "/data/iceberg-merge-into-demo"
+    sparkVersion: "3.5.0"
+    restartPolicy:
+      type: Never
+    sparkConf:
+      # Iceberg jars are pre-bundled on the Quanton image at /opt/spark/user-jars/.
+      spark.driver.extraClassPath: "local:///opt/spark/user-jars/iceberg-spark-runtime.jar:local:///opt/spark/user-jars/iceberg-spark-quanton.jar:local:///opt/spark/user-jars/iceberg-aws-bundle.jar"
+      spark.executor.extraClassPath: "local:///opt/spark/user-jars/iceberg-spark-runtime.jar:local:///opt/spark/user-jars/iceberg-spark-quanton.jar:local:///opt/spark/user-jars/iceberg-aws-bundle.jar"
+      spark.jars.ivy: "/tmp/ivy"
+    volumes:
+      - name: scripts
+        configMap:
+          name: quanton-iceberg-merge-into-demo-script
+      - name: iceberg-output
+        persistentVolumeClaim:
+          claimName: quanton-iceberg-merge-into-demo-pvc
+    driver:
+      cores: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      serviceAccount: spark-operator-spark
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: iceberg-output
+          mountPath: /data/iceberg-merge-into-demo
+    executor:
+      cores: 1
+      instances: 1
+      memory: "2048m"
+      labels:
+        version: "3.5.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: iceberg-output
+          mountPath: /data/iceberg-merge-into-demo


### PR DESCRIPTION
## Summary

Adds end-to-end `MERGE INTO` demos for Apache Hudi and Apache Iceberg, runnable on minikube via `QuantonSparkApplication`. Layout mirrors the existing `examples/clustering-demo/`.

- Each demo creates a `customers` table, inserts 10 rows, runs `MERGE INTO` with 3 updates + 3 inserts, and verifies the final state (`10 -> 13 rows, 3 'vip'`).
- **Hudi**: COW table with `primaryKey = id`, `preCombineField = ts`; pulls `hudi-spark3.5-bundle` from Maven on first run.
- **Iceberg**: Hadoop catalog on a PVC; no Glue / S3 needed.

## Files

```
examples/merge-into-demo/
├── README.md
├── hudi_merge_into_demo.py
├── iceberg_merge_into_demo.py
├── quanton-hudi-merge-into-demo.yaml
└── quanton-iceberg-merge-into-demo.yaml
```

## Test plan

- [x] `kubectl apply -f examples/merge-into-demo/quanton-iceberg-merge-into-demo.yaml` → driver pod `Succeeded`, log tail: `PASS — 10 -> 13 rows, 3 updated to 'vip'`
- [x] `kubectl apply -f examples/merge-into-demo/quanton-hudi-merge-into-demo.yaml` → driver pod `Succeeded`, log tail: `PASS — 10 -> 13 rows, 3 updated to 'vip'`
- [ ] Cleanup verified via `kubectl delete -f ...` + `kubectl delete pvc ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)