### PR TITLE
Update the default controller image to 2.0.6

### DIFF
--- a/charts/quanton-operator-chart/README.md
+++ b/charts/quanton-operator-chart/README.md
@@ -68,7 +68,7 @@ Key parameters:
 | `onehouseConfig.enableAIAgent` | Enable AI agent plugin for Spark applications | `true` |
 | `quantonOperator.jobNamespaces` | Namespaces where Spark jobs run | `["default"]` |
 | `quantonOperator.replicas` | Number of operator replicas | `1` |
-| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.5` |
+| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.6` |
 
 ## Chart Components
 

--- a/charts/quanton-operator-chart/README.md
+++ b/charts/quanton-operator-chart/README.md
@@ -65,10 +65,10 @@ Key parameters:
 |---|---|---|
 | `onehouseConfig.mtls.clientCert` | Client certificate in PEM format for mTLS | `""` |
 | `onehouseConfig.mtls.clientKey` | Client private key in PEM format for mTLS | `""` |
-| `onehouseConfig.enableAIAgent` | Enable AI agent plugin for Spark applications | `false` |
+| `onehouseConfig.enableAIAgent` | Enable AI agent plugin for Spark applications | `true` |
 | `quantonOperator.jobNamespaces` | Namespaces where Spark jobs run | `["default"]` |
 | `quantonOperator.replicas` | Number of operator replicas | `1` |
-| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.0` |
+| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.5` |
 
 ## Chart Components
 

--- a/charts/quanton-operator-chart/values.yaml
+++ b/charts/quanton-operator-chart/values.yaml
@@ -56,7 +56,7 @@ quantonOperator:
   nodeSelector: {}
     # node-type: "compute"
 
-  image: "dist.onehouse.ai/onehouseai/quanton-controller:2.0.3"
+  image: "dist.onehouse.ai/onehouseai/quanton-controller:2.0.5"
   pullPolicy: IfNotPresent
 
   replicas: 1

--- a/charts/quanton-operator-chart/values.yaml
+++ b/charts/quanton-operator-chart/values.yaml
@@ -56,7 +56,7 @@ quantonOperator:
   nodeSelector: {}
     # node-type: "compute"
 
-  image: "dist.onehouse.ai/onehouseai/quanton-controller:2.0.5"
+  image: "dist.onehouse.ai/onehouseai/quanton-controller:2.0.6"
   pullPolicy: IfNotPresent
 
   replicas: 1

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -36,7 +36,7 @@ These values control the behavior and resource allocation of the Quanton Operato
 
 | Parameter | Description | Default |
 |---|---|---|
-| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.0` |
+| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.5` |
 | `quantonOperator.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `quantonOperator.replicas` | Number of operator replicas | `1` |
 | `quantonOperator.serviceAccount.name` | Service account name for the operator | `quanton-operator` |

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -36,7 +36,7 @@ These values control the behavior and resource allocation of the Quanton Operato
 
 | Parameter | Description | Default |
 |---|---|---|
-| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.5` |
+| `quantonOperator.image` | Operator container image | `dist.onehouse.ai/onehouseai/quanton-controller:2.0.6` |
 | `quantonOperator.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `quantonOperator.replicas` | Number of operator replicas | `1` |
 | `quantonOperator.serviceAccount.name` | Service account name for the operator | `quanton-operator` |


### PR DESCRIPTION
Controller `2.0.6` is the first build that reads the Spark 4 engine image values added in #45, and it skips the AI agent on Spark 4, whose images do not ship it. The chart default was `2.0.3`, which ignores those values.

Also corrects two stale defaults in the docs tables: the operator image, listed as `2.0.0`, and `enableAIAgent` in the chart README, listed as `false`.

`helm lint` passes.