### PR TITLE
[ENG-47137] Add runnable RAG and fine-tuning demos for the two AI blogs

### DIFF
--- a/.claude/skills/run-rag-demo/SKILL.md
+++ b/.claude/skills/run-rag-demo/SKILL.md
@@ -82,7 +82,6 @@ Step 1 output is deterministic — check it exactly:
 
 ```
 |application/pdf  |SUCCESS        |pypdfium2  |510  |
-|text/html        |SUCCESS        |selectolax |2    |
 |application/x-csv|STRUCTURED_DATA|NULL       |1    |
 ```
 

--- a/.claude/skills/run-rag-demo/SKILL.md
+++ b/.claude/skills/run-rag-demo/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: run-rag-demo
+description: Run the RAG-on-the-lakehouse and fine-tuning demos on minikube — parses 510 real contract PDFs into Hudi tables on LANCE and PARQUET base files, embeds chunks, answers a question with cosine similarity joined to expert labels in one SQL statement, then exports a validated fine-tuning dataset
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# Run the RAG and fine-tuning demos
+
+You are a guided demo agent for the two AI demos in `examples/rag-and-fine-tuning/`. Run
+the chosen demo, give live progress, and report whether it passed.
+
+| Blog | Manifest | Script |
+|---|---|---|
+| [RAG on Your Lakehouse](https://quanton.dev/blog/rag-on-documents/) | `examples/rag-and-fine-tuning/quanton-rag-demo.yaml` | `rag_demo.py` |
+| [From Lakehouse Tables to a Fine-Tuning Dataset](https://quanton.dev/blog/fine-tuning-from-lakehouse-tables/) | `examples/rag-and-fine-tuning/quanton-finetune-demo.yaml` | `finetune_demo.py` |
+
+Each manifest is self-contained: a ConfigMap with the script inline, plus a
+QuantonSparkApplication. The RAG manifest also carries the shared PVC.
+
+**The fine-tuning demo reads the tables the RAG demo writes.** Never run it on its own
+against an empty PVC — check for `contract_chunks` first, and run the RAG demo if it is
+missing.
+
+## Phase 0: Interactive configuration
+
+Use AskUserQuestion. Keep it short.
+
+### Q1: Which demo?
+
+> "Which demo should I run?"
+
+Options:
+- **RAG only** — parse 510 contracts, embed chunks, retrieve with SQL.
+- **Fine-tuning only** — export an SFT dataset from tables a previous run produced.
+  Requires `contract_chunks` to exist already.
+- **Both** — RAG then fine-tuning, sequentially. This is the intended path.
+
+### Q2: How many chunks to embed?
+
+> "Embedding is the slow half. How many chunks?"
+
+Options:
+- **400 (default)** — a few minutes on minikube.
+- **2000** — a richer retrieval result, roughly 5x longer.
+- **All (~17.8k)** — pass `0`. Use a real cluster, not minikube; budget about an hour.
+
+Patch the second argument of `spec.sparkApplicationSpec.arguments` in the RAG manifest to
+match the answer. Do not edit anything else.
+
+### Q3: Cluster check (no question — just verify)
+
+```bash
+kubectl config current-context
+```
+
+Confirm it is `minikube`. If it is any other context, **stop** and tell the user to run
+`kubectl config use-context minikube` first — these manifests write to a PVC in
+`default` and are not meant for a shared cluster.
+
+Then confirm the operator can actually serve a Spark 4 image:
+
+```bash
+kubectl get configmap quanton-operator-config -n quanton-operator \
+  -o jsonpath='{.data.config\.json}' | python3 -m json.tool | grep -i spark4
+```
+
+If `quantonSpark4Image` is missing or empty, stop. The jobs declare
+`sparkVersion: "4.1.0"`, and the operator has no fallback — it fails the submission
+rather than quietly using a Spark 3 image. Tell the user to set
+`onehouseConfig.quantonSpark4Image` in their operator values. Chart 2.0.6 or newer is
+required; older charts have no such key at all.
+
+## Phase 1: Run
+
+```bash
+kubectl apply -f examples/rag-and-fine-tuning/quanton-rag-demo.yaml
+kubectl logs -f quanton-rag-demo-driver -n default
+```
+
+Report progress as the phases land. The first run downloads the corpus (~100 MB) and
+installs `sentence-transformers`, so expect several quiet minutes before step 1.
+
+Step 1 output is deterministic — check it exactly:
+
+```
+|application/pdf  |SUCCESS        |pypdfium2  |510  |
+|text/html        |SUCCESS        |selectolax |2    |
+|application/x-csv|STRUCTURED_DATA|NULL       |1    |
+```
+
+If the PDF count is not 510, the corpus download was truncated. Delete the PVC and rerun
+rather than reporting a partial result.
+
+Then for fine-tuning:
+
+```bash
+kubectl apply -f examples/rag-and-fine-tuning/quanton-finetune-demo.yaml
+kubectl logs -f quanton-finetune-demo-driver -n default
+```
+
+## Phase 2: Report
+
+For the RAG demo, show the user three things and say what each one demonstrates:
+
+1. **The routing table** — one engine picked a parser per file, and left the CSV to the
+   native readers instead of mangling it through a text extractor.
+2. **The cosine top-5 joined to the expert labels** — how many of the retrieved contracts
+   carry the expert `Non-Compete` label. This is the accuracy signal. Do not present a
+   high cosine as correctness on its own.
+3. **The coverage `GROUP BY`** — a CSV supplied the labels, PDFs supplied the chunks, and
+   one query read both across PARQUET and LANCE base files. It needs no vector search,
+   which is the argument for keeping vectors next to the relational data.
+
+For fine-tuning, show the two `_manifest.json` blocks and point out that `upload` is
+absent — the writer produces the dataset and never talks to a provider.
+
+Both end with a `PASS —` line. Quote it.
+
+## Troubleshooting
+
+**`NameError: name 'torch' is not defined`** in a `mapInPandas` task. Expected on the
+first attempt if a Python worker imported while the install was still in flight; Spark
+retries and the retry succeeds. If every attempt fails, the `sys.modules` purge in
+`ensure_sentence_transformers()` is not running — check the script in the ConfigMap
+matches `rag_demo.py` on disk.
+
+**Driver evicted, `Evicted pod: Underutilized`.** Only on clusters running Karpenter, not
+minikube. Add `spark.kubernetes.driver.annotation.karpenter.sh/do-not-disrupt: "true"`.
+
+**`No object store provider found for scheme: 's3a'`.** You pointed the demo at object
+storage using `s3a://`. Lance's writer is native Rust with its own object-store layer and
+has no `s3a` provider. Use `s3://` and register
+`fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem`.
+
+**A bare `count()` returns 0** on a lance table. A Hudi 1.2.0 bug with empty-projection
+scans — the data is fine. Aggregate over a named column instead.
+
+## Cleanup
+
+```bash
+kubectl delete -f examples/rag-and-fine-tuning/quanton-finetune-demo.yaml
+kubectl delete -f examples/rag-and-fine-tuning/quanton-rag-demo.yaml
+```
+
+Deleting the RAG manifest removes the PVC and therefore the corpus, so a rerun downloads
+it again. Ask before deleting if the user may want to rerun.

--- a/.claude/skills/run-rag-demo/SKILL.md
+++ b/.claude/skills/run-rag-demo/SKILL.md
@@ -65,10 +65,8 @@ kubectl get configmap quanton-operator-config -n quanton-operator \
 ```
 
 If `quantonSpark4Image` is missing or empty, stop. The jobs declare
-`sparkVersion: "4.1.0"`, and the operator has no fallback — it fails the submission
-rather than quietly using a Spark 3 image. Tell the user to set
-`onehouseConfig.quantonSpark4Image` in their operator values. Chart 2.0.6 or newer is
-required; older charts have no such key at all.
+`sparkVersion: "4.1.0"`, which requires that image. Tell the user to set
+`onehouseConfig.quantonSpark4Image` in their operator values (chart 2.0.6 or newer).
 
 ## Phase 1: Run
 
@@ -103,7 +101,7 @@ kubectl logs -f quanton-finetune-demo-driver -n default
 For the RAG demo, show the user three things and say what each one demonstrates:
 
 1. **The routing table** — one engine picked a parser per file, and left the CSV to the
-   native readers instead of mangling it through a text extractor.
+   native readers rather than a text extractor.
 2. **The cosine top-5 joined to the expert labels** — how many of the retrieved contracts
    carry the expert `Non-Compete` label. This is the accuracy signal. Do not present a
    high cosine as correctness on its own.
@@ -118,22 +116,17 @@ Both end with a `PASS —` line. Quote it.
 
 ## Troubleshooting
 
-**`NameError: name 'torch' is not defined`** in a `mapInPandas` task. Expected on the
-first attempt if a Python worker imported while the install was still in flight; Spark
-retries and the retry succeeds. If every attempt fails, the `sys.modules` purge in
-`ensure_sentence_transformers()` is not running — check the script in the ConfigMap
-matches `rag_demo.py` on disk.
+**`NameError: name 'torch' is not defined`** in a `mapInPandas` task. A Python worker
+imported `transformers` before the install finished. Spark retries the task and the retry
+succeeds. If every attempt fails, check that the script in the ConfigMap matches
+`rag_demo.py` on disk.
 
 **Driver evicted, `Evicted pod: Underutilized`.** Only on clusters running Karpenter, not
 minikube. Add `spark.kubernetes.driver.annotation.karpenter.sh/do-not-disrupt: "true"`.
 
 **`No object store provider found for scheme: 's3a'`.** You pointed the demo at object
-storage using `s3a://`. Lance's writer is native Rust with its own object-store layer and
-has no `s3a` provider. Use `s3://` and register
-`fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem`.
-
-**A bare `count()` returns 0** on a lance table. A Hudi 1.2.0 bug with empty-projection
-scans — the data is fine. Aggregate over a named column instead.
+storage using `s3a://`. Lance uses its own object-store layer, which does not recognise
+`s3a`. Use `s3://` and register `fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem`.
 
 ## Cleanup
 

--- a/examples/rag-and-fine-tuning/README.md
+++ b/examples/rag-and-fine-tuning/README.md
@@ -40,7 +40,6 @@ Step 1 reports what the reader found:
 |content_type     |parse_status   |parser_used|files|
 +-----------------+---------------+-----------+-----+
 |application/pdf  |SUCCESS        |pypdfium2  |510  |
-|text/html        |SUCCESS        |selectolax |2    |
 |application/x-csv|STRUCTURED_DATA|NULL       |1    |
 +-----------------+---------------+-----------+-----+
 ```
@@ -55,7 +54,7 @@ retrieved contracts carry the expert `Non-Compete` label, and a `GROUP BY` that 
 vector search. It ends with:
 
 ```
-[rag-demo] PASS — documents(lance)=512 chunks(lance)=400 annotations(parquet)=...
+[rag-demo] PASS — documents(lance)=510 chunks(lance)=400 annotations(parquet)=...
 ```
 
 ### 2. Fine-tuning
@@ -100,7 +99,14 @@ job code. `rag_demo.py` installs `sentence-transformers` from the CPU wheel inde
 skips the CUDA packages. The fine-tuning demo installs nothing. If you use
 `sentence-transformers` under `mapInPandas` in your own job, `ensure_sentence_transformers()`
 in [`rag_demo.py`](rag_demo.py) shows how to install once per executor across reused
-Python workers.
+Python workers. The installed versions are bounded by major version: `sentence-transformers`
+5 and later cannot build a plain text BERT tokenizer, and `transformers` 4.x does not
+catch the error `huggingface_hub` 1.x raises for a model with no chat template.
+
+**The embedding executor needs a larger overhead budget.** torch lives outside the JVM
+heap, so `spark.executor.memoryOverheadFactor` is `1.2` where the driver keeps `0.3`. At
+the driver's factor the embedding stage loses executors to the OOM killer. The
+fine-tuning demo loads no torch and keeps `0.3`.
 
 ## Storage
 

--- a/examples/rag-and-fine-tuning/README.md
+++ b/examples/rag-and-fine-tuning/README.md
@@ -1,0 +1,125 @@
+# RAG and fine-tuning on the lakehouse
+
+Runnable companions to two blog posts. Both run on Kubernetes through
+`QuantonSparkApplication`, on the **Spark 4** image.
+
+| Blog | Manifest | Script |
+|------|----------|--------|
+| [RAG on Your Lakehouse](https://quanton.dev/blog/rag-on-documents/) | [`quanton-rag-demo.yaml`](quanton-rag-demo.yaml) | [`rag_demo.py`](rag_demo.py) |
+| [From Lakehouse Tables to a Fine-Tuning Dataset](https://quanton.dev/blog/fine-tuning-from-lakehouse-tables/) | [`quanton-finetune-demo.yaml`](quanton-finetune-demo.yaml) | [`finetune_demo.py`](finetune_demo.py) |
+
+The corpus is [CUAD](https://huggingface.co/datasets/theatticusproject/cuad) (CC-BY-4.0):
+510 real commercial contracts as PDFs, plus a CSV of clause labels that lawyers wrote.
+About 100 MB, fetched on first run. The PDFs are the unstructured side and the labels are
+the structured side — the whole point is that one engine reads both and they end up
+joinable in one SQL statement.
+
+Run the RAG demo first. The fine-tuning demo reads the tables it produces.
+
+## Prerequisites
+
+- minikube running with at least 4 CPUs / 8 GB RAM
+- Spark Operator and Quanton Operator installed and `Running`
+  (see [`../../README.md`](../../README.md))
+- `onehouseConfig.quantonSpark4Image` set in your operator values — these jobs declare
+  `sparkVersion: "4.1.0"`, which is what selects that image
+- Outbound network access, for the corpus and the embedding model
+
+## Run
+
+### 1. RAG
+
+```bash
+kubectl apply -f quanton-rag-demo.yaml
+kubectl logs -f quanton-rag-demo-driver -n default
+```
+
+Step 1 reports what the reader found, and this part is deterministic:
+
+```
++-----------------+---------------+-----------+-----+
+|content_type     |parse_status   |parser_used|files|
++-----------------+---------------+-----------+-----+
+|application/pdf  |SUCCESS        |pypdfium2  |510  |
+|text/html        |SUCCESS        |selectolax |2    |
+|application/x-csv|STRUCTURED_DATA|NULL       |1    |
++-----------------+---------------+-----------+-----+
+```
+
+The CSV is flagged `STRUCTURED_DATA` rather than dragged through a text extractor — the
+reader leaves it to the native readers, and the demo then reads it as a table.
+
+Then two Hudi tables land, `contract_documents` on **LANCE** base files and
+`contract_annotations` on **PARQUET**, chunks are embedded, and step 4 runs three
+queries: a cosine top-5, the same ranking joined against the relational table to check
+whether the retrieved contracts really carry the expert `Non-Compete` label, and a
+`GROUP BY` that needs no vector search at all. It ends with:
+
+```
+[rag-demo] PASS — documents(lance)=512 chunks(lance)=400 annotations(parquet)=...
+```
+
+### 2. Fine-tuning
+
+```bash
+kubectl apply -f quanton-finetune-demo.yaml
+kubectl logs -f quanton-finetune-demo-driver -n default
+```
+
+It locates each expert-annotated clause span inside the chunk that contains it, builds
+SFT rows from those, and exports twice — validated Together JSONL, and tokenized parquet
+with a token manifest — printing both `_manifest.json` files. Nothing is uploaded
+anywhere; the manifest's `load` section names the command you still owe.
+
+## Scale
+
+`rag_demo.py` takes a chunk cap as its second argument, defaulting to **400** so a
+minikube run finishes in minutes:
+
+```yaml
+arguments:
+  - "/data/rag-demo"
+  - "400"          # 0 embeds every chunk (~17.8k on the full corpus)
+```
+
+All 510 contracts are always parsed and written — the cap applies only to embedding,
+which is the expensive half. On a real cluster, raise it or pass `0`.
+
+## Notes
+
+Three things in these manifests are not obvious, and all three are load-bearing.
+
+**The image is chosen by `sparkVersion`, not by `image:`.** The operator overrides any
+image in the job spec. `sparkVersion: "4.1.0"` plus the default accelerator (`native`)
+resolves to `onehouseConfig.quantonSpark4Image`. Quote the version — an unquoted
+`4.1` is a YAML number and the job is rejected.
+
+**The Hudi and Lance config is repeated in `sparkConf`.** The Spark 4 image bakes
+`extraClassPath`, `spark.sql.extensions`, the Kryo serializer and the Hoodie registrator
+into its `spark-defaults.conf`, but the operator regenerates `spark.properties` from the
+CRD and never reads that file. Drop those lines and neither format is available at
+runtime.
+
+**Embeddings are installed by the job, on purpose.** The image ships
+`quanton_unstructured`, `quanton_llm_training`, Hudi and Lance, but deliberately not
+`sentence-transformers` — torch would roughly double the image, and embedding is job
+code. `rag_demo.py` installs it against the CPU wheel index; the default index pulls
+`nvidia/` and `triton/`, about 3.5 GB of CUDA that never runs on a CPU node. The
+fine-tuning demo installs nothing at all.
+
+If you use `sentence-transformers` under `mapInPandas` in your own job, read
+`ensure_sentence_transformers()` in [`rag_demo.py`](rag_demo.py) before writing your own.
+Spark reuses Python workers, and the image already ships a torch-less `transformers`, so
+a worker that imports while the install is still in flight caches that copy in
+`sys.modules` permanently and fails with `NameError: name 'torch' is not defined` even
+after the install completes. The fix is a marker file checked under an `flock`, plus
+purging `transformers` from `sys.modules`.
+
+## Storage
+
+Both jobs share one `ReadWriteOnce` PVC mounted at `/data/rag-demo` on the driver and the
+executor, which is why the executor count is 1 — the corpus and the Hudi tables have to
+be visible to both pods. On a real cluster, point the arguments at object storage
+instead and drop the PVC. Use `s3://` rather than `s3a://`: Lance's base-file writer is
+native Rust with its own object-store layer and has no `s3a` provider, and pyarrow does
+not recognise `s3a` either. Register `fs.s3.impl` so Hadoop resolves the same paths.

--- a/examples/rag-and-fine-tuning/README.md
+++ b/examples/rag-and-fine-tuning/README.md
@@ -9,10 +9,9 @@ Runnable companions to two blog posts. Both run on Kubernetes through
 | [From Lakehouse Tables to a Fine-Tuning Dataset](https://quanton.dev/blog/fine-tuning-from-lakehouse-tables/) | [`quanton-finetune-demo.yaml`](quanton-finetune-demo.yaml) | [`finetune_demo.py`](finetune_demo.py) |
 
 The corpus is [CUAD](https://huggingface.co/datasets/theatticusproject/cuad) (CC-BY-4.0):
-510 real commercial contracts as PDFs, plus a CSV of clause labels that lawyers wrote.
-About 100 MB, fetched on first run. The PDFs are the unstructured side and the labels are
-the structured side — the whole point is that one engine reads both and they end up
-joinable in one SQL statement.
+510 real commercial contracts as PDFs, plus a CSV of expert-written clause labels. About
+100 MB, fetched on first run. The PDFs are the unstructured side and the labels are the
+structured side. One engine reads both, and they are joinable in one SQL statement.
 
 Run the RAG demo first. The fine-tuning demo reads the tables it produces.
 
@@ -21,8 +20,8 @@ Run the RAG demo first. The fine-tuning demo reads the tables it produces.
 - minikube running with at least 4 CPUs / 8 GB RAM
 - Spark Operator and Quanton Operator installed and `Running`
   (see [`../../README.md`](../../README.md))
-- `onehouseConfig.quantonSpark4Image` set in your operator values — these jobs declare
-  `sparkVersion: "4.1.0"`, which is what selects that image
+- Chart 2.0.6 or newer, with `onehouseConfig.quantonSpark4Image` set in your operator
+  values. These jobs declare `sparkVersion: "4.1.0"`, which selects that image.
 - Outbound network access, for the corpus and the embedding model
 
 ## Run
@@ -34,7 +33,7 @@ kubectl apply -f quanton-rag-demo.yaml
 kubectl logs -f quanton-rag-demo-driver -n default
 ```
 
-Step 1 reports what the reader found, and this part is deterministic:
+Step 1 reports what the reader found:
 
 ```
 +-----------------+---------------+-----------+-----+
@@ -46,14 +45,14 @@ Step 1 reports what the reader found, and this part is deterministic:
 +-----------------+---------------+-----------+-----+
 ```
 
-The CSV is flagged `STRUCTURED_DATA` rather than dragged through a text extractor — the
-reader leaves it to the native readers, and the demo then reads it as a table.
+The CSV is flagged `STRUCTURED_DATA` and left to the native readers. The demo then reads
+it as a table.
 
-Then two Hudi tables land, `contract_documents` on **LANCE** base files and
-`contract_annotations` on **PARQUET**, chunks are embedded, and step 4 runs three
-queries: a cosine top-5, the same ranking joined against the relational table to check
-whether the retrieved contracts really carry the expert `Non-Compete` label, and a
-`GROUP BY` that needs no vector search at all. It ends with:
+Two Hudi tables land, `contract_documents` on **LANCE** base files and
+`contract_annotations` on **PARQUET**. Chunks are embedded, and step 4 runs three queries:
+a cosine top-5, the same ranking joined against the relational table to check whether the
+retrieved contracts carry the expert `Non-Compete` label, and a `GROUP BY` that needs no
+vector search. It ends with:
 
 ```
 [rag-demo] PASS — documents(lance)=512 chunks(lance)=400 annotations(parquet)=...
@@ -67,9 +66,9 @@ kubectl logs -f quanton-finetune-demo-driver -n default
 ```
 
 It locates each expert-annotated clause span inside the chunk that contains it, builds
-SFT rows from those, and exports twice — validated Together JSONL, and tokenized parquet
-with a token manifest — printing both `_manifest.json` files. Nothing is uploaded
-anywhere; the manifest's `load` section names the command you still owe.
+SFT rows from those, and exports twice: validated Together JSONL, and tokenized parquet
+with a token manifest. Both `_manifest.json` files are printed. Nothing is uploaded; the
+manifest's `load` section names the upload command.
 
 ## Scale
 
@@ -82,44 +81,31 @@ arguments:
   - "400"          # 0 embeds every chunk (~17.8k on the full corpus)
 ```
 
-All 510 contracts are always parsed and written — the cap applies only to embedding,
-which is the expensive half. On a real cluster, raise it or pass `0`.
+All 510 contracts are always parsed and written. The cap applies only to embedding. On a
+real cluster, raise it or pass `0`.
 
 ## Notes
 
-Three things in these manifests are not obvious, and all three are load-bearing.
+**`sparkVersion` selects the image.** `sparkVersion: "4.1.0"` with the default accelerator
+(`native`) resolves to `onehouseConfig.quantonSpark4Image`; the `image:` field is a
+placeholder. Quote the version so YAML reads it as a string.
 
-**The image is chosen by `sparkVersion`, not by `image:`.** The operator overrides any
-image in the job spec. `sparkVersion: "4.1.0"` plus the default accelerator (`native`)
-resolves to `onehouseConfig.quantonSpark4Image`. Quote the version — an unquoted
-`4.1` is a YAML number and the job is rejected.
+**Hudi and Lance settings live in `sparkConf`.** The operator builds `spark.properties`
+from the CRD, so `extraClassPath`, `spark.sql.extensions`, the Kryo serializer and the
+Hoodie registrator are set there.
 
-**The Hudi and Lance config is repeated in `sparkConf`.** The Spark 4 image bakes
-`extraClassPath`, `spark.sql.extensions`, the Kryo serializer and the Hoodie registrator
-into its `spark-defaults.conf`, but the operator regenerates `spark.properties` from the
-CRD and never reads that file. Drop those lines and neither format is available at
-runtime.
-
-**Embeddings are installed by the job, on purpose.** The image ships
-`quanton_unstructured`, `quanton_llm_training`, Hudi and Lance, but deliberately not
-`sentence-transformers` — torch would roughly double the image, and embedding is job
-code. `rag_demo.py` installs it against the CPU wheel index; the default index pulls
-`nvidia/` and `triton/`, about 3.5 GB of CUDA that never runs on a CPU node. The
-fine-tuning demo installs nothing at all.
-
-If you use `sentence-transformers` under `mapInPandas` in your own job, read
-`ensure_sentence_transformers()` in [`rag_demo.py`](rag_demo.py) before writing your own.
-Spark reuses Python workers, and the image already ships a torch-less `transformers`, so
-a worker that imports while the install is still in flight caches that copy in
-`sys.modules` permanently and fails with `NameError: name 'torch' is not defined` even
-after the install completes. The fix is a marker file checked under an `flock`, plus
-purging `transformers` from `sys.modules`.
+**`sentence-transformers` is installed by the job.** The image ships
+`quanton_unstructured`, `quanton_llm_training`, Hudi and Lance; embedding libraries are
+job code. `rag_demo.py` installs `sentence-transformers` from the CPU wheel index, which
+skips the CUDA packages. The fine-tuning demo installs nothing. If you use
+`sentence-transformers` under `mapInPandas` in your own job, `ensure_sentence_transformers()`
+in [`rag_demo.py`](rag_demo.py) shows how to install once per executor across reused
+Python workers.
 
 ## Storage
 
 Both jobs share one `ReadWriteOnce` PVC mounted at `/data/rag-demo` on the driver and the
-executor, which is why the executor count is 1 — the corpus and the Hudi tables have to
-be visible to both pods. On a real cluster, point the arguments at object storage
-instead and drop the PVC. Use `s3://` rather than `s3a://`: Lance's base-file writer is
-native Rust with its own object-store layer and has no `s3a` provider, and pyarrow does
-not recognise `s3a` either. Register `fs.s3.impl` so Hadoop resolves the same paths.
+executor, so the executor count is 1. On a real cluster, point the arguments at object
+storage and drop the PVC. Use `s3://` rather than `s3a://`, since Lance and pyarrow use
+their own object-store layers, and set `fs.s3.impl=org.apache.hadoop.fs.s3a.S3AFileSystem`
+so Hadoop resolves the same paths.

--- a/examples/rag-and-fine-tuning/finetune_demo.py
+++ b/examples/rag-and-fine-tuning/finetune_demo.py
@@ -13,8 +13,7 @@ span is located inside the parsed chunk that contains it, giving
     -> format("training_dataset")  -> validated Together SFT JSONL + _manifest.json
                                    -> tokenized parquet + token manifest
 
-Nothing is installed: the image ships quanton_llm_training, and its `tokenized` extra is
-transformers + jinja2, which are Rust tokenizers and pull no torch.
+Nothing is installed: the image ships quanton_llm_training.
 
 Usage: finetune_demo.py <data_dir> [max_rows]
 """
@@ -32,9 +31,7 @@ DATA = sys.argv[1] if len(sys.argv) > 1 else "/data/rag-demo"
 MAX_ROWS = int(sys.argv[2]) if len(sys.argv) > 2 else 500
 
 TABLES, EXPORTS = f"{DATA}/tables", f"{DATA}/exports"
-# An exported training dataset is immutable, so format("training_dataset") refuses to
-# write into a path that already holds one. A UTC stamp gives each run its own version
-# directory. The Hudi tables are the opposite contract on purpose: they upsert in place.
+# Exported datasets are immutable, so each run writes its own versioned directory.
 VERSION = os.environ.get("QU_EXPORT_VERSION",
                          datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
 
@@ -56,8 +53,6 @@ annotations = (read_hudi("contract_annotations")
                .where(F.length("span") > 40))
 
 # Whitespace-normalised prefix match: find the chunk that contains each expert span.
-# This is the grounding step -- a human lawyer marked the span, so the answer is not
-# something the model invented.
 norm = lambda c: F.lower(F.regexp_replace(c, r"\s+", " "))  # noqa: E731
 positives = (annotations
              .withColumn("span_key", F.substring(norm(F.col("span")), 1, 120))
@@ -118,8 +113,7 @@ tokenized_path = f"{EXPORTS}/cuad-analyst-sft-tokenized/{VERSION}"
       .save(tokenized_path))
 print(f"[finetune-demo] tokenized parquet + manifest -> {tokenized_path}", flush=True)
 
-# The writer produces the dataset in object storage and never uploads. The manifest's
-# `load` section names the command the caller still owes.
+# The writer never uploads. The manifest's `load` section names the upload command.
 for p in (jsonl_path, tokenized_path):
     for m in glob.glob(os.path.join(p, "_manifest.json")):
         print(f"\n[finetune-demo] _manifest.json ({os.path.basename(p)}):", flush=True)

--- a/examples/rag-and-fine-tuning/finetune_demo.py
+++ b/examples/rag-and-fine-tuning/finetune_demo.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""From lakehouse tables to a fine-tuning dataset — the blog, on Kubernetes.
+
+  https://quanton.dev/blog/fine-tuning-from-lakehouse-tables/
+
+Reads the tables rag_demo.py produced and turns them into a validated fine-tuning
+dataset. Every training row is grounded in an expert annotation: each labelled clause
+span is located inside the parsed chunk that contains it, giving
+(question about the clause, chunk as context, expert answer).
+
+  contract_chunks (LANCE) x contract_annotations (PARQUET)
+    -> build the rows in SQL
+    -> format("training_dataset")  -> validated Together SFT JSONL + _manifest.json
+                                   -> tokenized parquet + token manifest
+
+Nothing is installed: the image ships quanton_llm_training, and its `tokenized` extra is
+transformers + jinja2, which are Rust tokenizers and pull no torch.
+
+Usage: finetune_demo.py <data_dir> [max_rows]
+"""
+
+import glob
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+DATA = sys.argv[1] if len(sys.argv) > 1 else "/data/rag-demo"
+MAX_ROWS = int(sys.argv[2]) if len(sys.argv) > 2 else 500
+
+TABLES, EXPORTS = f"{DATA}/tables", f"{DATA}/exports"
+# An exported training dataset is immutable, so format("training_dataset") refuses to
+# write into a path that already holds one. A UTC stamp gives each run its own version
+# directory. The Hudi tables are the opposite contract on purpose: they upsert in place.
+VERSION = os.environ.get("QU_EXPORT_VERSION",
+                         datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+
+spark = SparkSession.builder.appName("finetune_demo").getOrCreate()
+spark.sparkContext.setLogLevel("WARN")
+
+import quanton_llm_training
+
+quanton_llm_training.register(spark)
+
+
+def read_hudi(name):
+    return spark.read.format("hudi").load(f"{TABLES}/{name}")
+
+
+chunks = read_hudi("contract_chunks").select("file_name", "pos", "chunk")
+annotations = (read_hudi("contract_annotations")
+               .select("file_name", "clause_type", F.explode("clause_spans").alias("span"))
+               .where(F.length("span") > 40))
+
+# Whitespace-normalised prefix match: find the chunk that contains each expert span.
+# This is the grounding step -- a human lawyer marked the span, so the answer is not
+# something the model invented.
+norm = lambda c: F.lower(F.regexp_replace(c, r"\s+", " "))  # noqa: E731
+positives = (annotations
+             .withColumn("span_key", F.substring(norm(F.col("span")), 1, 120))
+             .join(chunks.withColumn("chunk_norm", norm(F.col("chunk"))), "file_name")
+             .where(F.expr("instr(chunk_norm, span_key) > 0"))
+             .groupBy("file_name", "clause_type", "span")
+             .agg(F.first("chunk").alias("chunk")))
+
+n_pos = positives.agg(F.count("span").alias("c")).first()["c"]
+print(f"\n[finetune-demo] expert spans located in parsed chunks: {n_pos}", flush=True)
+
+train = positives.select(
+    F.array(
+        F.struct(
+            F.lit("system").alias("role"),
+            F.lit("You are a contract analyst. Answer strictly from the excerpt; "
+                  "quote the contract language that supports your answer.").alias("content"),
+        ),
+        F.struct(
+            F.lit("user").alias("role"),
+            F.concat(
+                F.lit('Does the following contract excerpt contain a "'),
+                F.col("clause_type"),
+                F.lit('" clause? If yes, quote the relevant language.\n\nExcerpt:\n'),
+                F.col("chunk"),
+            ).alias("content"),
+        ),
+        F.struct(
+            F.lit("assistant").alias("role"),
+            F.concat(
+                F.lit("Yes. This excerpt contains a "),
+                F.col("clause_type"),
+                F.lit(' clause: "'),
+                F.substring(F.col("span"), 1, 800),
+                F.lit('"'),
+            ).alias("content"),
+        ),
+    ).alias("messages")
+).limit(MAX_ROWS)
+
+jsonl_path = f"{EXPORTS}/cuad-analyst-sft/{VERSION}"
+(train.write.format("training_dataset")
+      .option("provider", "together")
+      .option("training_type", "sft")
+      .mode("append")
+      .save(jsonl_path))
+print(f"[finetune-demo] validated Together SFT JSONL -> {jsonl_path}", flush=True)
+
+# outputFormat=tokenized emits parquet plus a token manifest, so you know the token bill
+# and the truncation count before you pay for a training run.
+tokenized_path = f"{EXPORTS}/cuad-analyst-sft-tokenized/{VERSION}"
+(train.limit(200).write.format("training_dataset")
+      .option("provider", "together")
+      .option("training_type", "sft")
+      .option("outputFormat", "tokenized")
+      .option("tokenizer", "Qwen/Qwen2.5-0.5B-Instruct")
+      .mode("append")
+      .save(tokenized_path))
+print(f"[finetune-demo] tokenized parquet + manifest -> {tokenized_path}", flush=True)
+
+# The writer produces the dataset in object storage and never uploads. The manifest's
+# `load` section names the command the caller still owes.
+for p in (jsonl_path, tokenized_path):
+    for m in glob.glob(os.path.join(p, "_manifest.json")):
+        print(f"\n[finetune-demo] _manifest.json ({os.path.basename(p)}):", flush=True)
+        print(json.dumps(json.load(open(m)), indent=2), flush=True)
+
+print(f"\n[finetune-demo] PASS — {n_pos} grounded spans, "
+      f"exported {min(n_pos, MAX_ROWS)} SFT rows", flush=True)
+spark.stop()

--- a/examples/rag-and-fine-tuning/quanton-finetune-demo.yaml
+++ b/examples/rag-and-fine-tuning/quanton-finetune-demo.yaml
@@ -1,0 +1,204 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quanton-finetune-demo-script
+  namespace: default
+data:
+  finetune_demo.py: |
+    #!/usr/bin/env python3
+    """From lakehouse tables to a fine-tuning dataset — the blog, on Kubernetes.
+
+      https://quanton.dev/blog/fine-tuning-from-lakehouse-tables/
+
+    Reads the tables rag_demo.py produced and turns them into a validated fine-tuning
+    dataset. Every training row is grounded in an expert annotation: each labelled clause
+    span is located inside the parsed chunk that contains it, giving
+    (question about the clause, chunk as context, expert answer).
+
+      contract_chunks (LANCE) x contract_annotations (PARQUET)
+        -> build the rows in SQL
+        -> format("training_dataset")  -> validated Together SFT JSONL + _manifest.json
+                                       -> tokenized parquet + token manifest
+
+    Nothing is installed: the image ships quanton_llm_training, and its `tokenized` extra is
+    transformers + jinja2, which are Rust tokenizers and pull no torch.
+
+    Usage: finetune_demo.py <data_dir> [max_rows]
+    """
+
+    import glob
+    import json
+    import os
+    import sys
+    from datetime import datetime, timezone
+
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    DATA = sys.argv[1] if len(sys.argv) > 1 else "/data/rag-demo"
+    MAX_ROWS = int(sys.argv[2]) if len(sys.argv) > 2 else 500
+
+    TABLES, EXPORTS = f"{DATA}/tables", f"{DATA}/exports"
+    # An exported training dataset is immutable, so format("training_dataset") refuses to
+    # write into a path that already holds one. A UTC stamp gives each run its own version
+    # directory. The Hudi tables are the opposite contract on purpose: they upsert in place.
+    VERSION = os.environ.get("QU_EXPORT_VERSION",
+                             datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
+
+    spark = SparkSession.builder.appName("finetune_demo").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+    import quanton_llm_training
+
+    quanton_llm_training.register(spark)
+
+
+    def read_hudi(name):
+        return spark.read.format("hudi").load(f"{TABLES}/{name}")
+
+
+    chunks = read_hudi("contract_chunks").select("file_name", "pos", "chunk")
+    annotations = (read_hudi("contract_annotations")
+                   .select("file_name", "clause_type", F.explode("clause_spans").alias("span"))
+                   .where(F.length("span") > 40))
+
+    # Whitespace-normalised prefix match: find the chunk that contains each expert span.
+    # This is the grounding step -- a human lawyer marked the span, so the answer is not
+    # something the model invented.
+    norm = lambda c: F.lower(F.regexp_replace(c, r"\s+", " "))  # noqa: E731
+    positives = (annotations
+                 .withColumn("span_key", F.substring(norm(F.col("span")), 1, 120))
+                 .join(chunks.withColumn("chunk_norm", norm(F.col("chunk"))), "file_name")
+                 .where(F.expr("instr(chunk_norm, span_key) > 0"))
+                 .groupBy("file_name", "clause_type", "span")
+                 .agg(F.first("chunk").alias("chunk")))
+
+    n_pos = positives.agg(F.count("span").alias("c")).first()["c"]
+    print(f"\n[finetune-demo] expert spans located in parsed chunks: {n_pos}", flush=True)
+
+    train = positives.select(
+        F.array(
+            F.struct(
+                F.lit("system").alias("role"),
+                F.lit("You are a contract analyst. Answer strictly from the excerpt; "
+                      "quote the contract language that supports your answer.").alias("content"),
+            ),
+            F.struct(
+                F.lit("user").alias("role"),
+                F.concat(
+                    F.lit('Does the following contract excerpt contain a "'),
+                    F.col("clause_type"),
+                    F.lit('" clause? If yes, quote the relevant language.\n\nExcerpt:\n'),
+                    F.col("chunk"),
+                ).alias("content"),
+            ),
+            F.struct(
+                F.lit("assistant").alias("role"),
+                F.concat(
+                    F.lit("Yes. This excerpt contains a "),
+                    F.col("clause_type"),
+                    F.lit(' clause: "'),
+                    F.substring(F.col("span"), 1, 800),
+                    F.lit('"'),
+                ).alias("content"),
+            ),
+        ).alias("messages")
+    ).limit(MAX_ROWS)
+
+    jsonl_path = f"{EXPORTS}/cuad-analyst-sft/{VERSION}"
+    (train.write.format("training_dataset")
+          .option("provider", "together")
+          .option("training_type", "sft")
+          .mode("append")
+          .save(jsonl_path))
+    print(f"[finetune-demo] validated Together SFT JSONL -> {jsonl_path}", flush=True)
+
+    # outputFormat=tokenized emits parquet plus a token manifest, so you know the token bill
+    # and the truncation count before you pay for a training run.
+    tokenized_path = f"{EXPORTS}/cuad-analyst-sft-tokenized/{VERSION}"
+    (train.limit(200).write.format("training_dataset")
+          .option("provider", "together")
+          .option("training_type", "sft")
+          .option("outputFormat", "tokenized")
+          .option("tokenizer", "Qwen/Qwen2.5-0.5B-Instruct")
+          .mode("append")
+          .save(tokenized_path))
+    print(f"[finetune-demo] tokenized parquet + manifest -> {tokenized_path}", flush=True)
+
+    # The writer produces the dataset in object storage and never uploads. The manifest's
+    # `load` section names the command the caller still owes.
+    for p in (jsonl_path, tokenized_path):
+        for m in glob.glob(os.path.join(p, "_manifest.json")):
+            print(f"\n[finetune-demo] _manifest.json ({os.path.basename(p)}):", flush=True)
+            print(json.dumps(json.load(open(m)), indent=2), flush=True)
+
+    print(f"\n[finetune-demo] PASS — {n_pos} grounded spans, "
+          f"exported {min(n_pos, MAX_ROWS)} SFT rows", flush=True)
+    spark.stop()
+
+---
+apiVersion: quantonsparkoperator.onehouse.ai/v1beta2
+kind: QuantonSparkApplication
+metadata:
+  name: quanton-finetune-demo
+  namespace: default
+spec:
+  sparkApplicationSpec:
+    type: Python
+    mode: cluster
+    # Placeholder. The operator overrides it: sparkVersion 4.x + the default
+    # accelerator (native) resolve to onehouseConfig.quantonSpark4Image.
+    image: "apache/spark:4.0.0"
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: "local:///mnt/scripts/finetune_demo.py"
+    arguments:
+      - "/data/rag-demo"
+      - "500"
+    # 4.1.x selects the Spark 4 line. Quote it -- an unquoted 4.1 is a YAML number
+    # and the job is rejected.
+    sparkVersion: "4.1.0"
+    restartPolicy:
+      type: Never
+    sparkConf:
+      # The operator regenerates spark.properties from this block and bypasses the image's
+      # /opt/spark/conf/spark-defaults.conf entirely, so the Hudi + Lance wiring the image
+      # bakes in MUST be repeated here or neither format is available at runtime.
+      spark.driver.extraClassPath: "/opt/spark/user-jars/*"
+      spark.executor.extraClassPath: "/opt/spark/user-jars/*"
+      spark.sql.extensions: org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+      spark.serializer: org.apache.spark.serializer.KryoSerializer
+      spark.kryo.registrator: org.apache.spark.HoodieSparkKryoRegistrar
+      spark.sql.shuffle.partitions: "8"
+      spark.sql.execution.arrow.maxRecordsPerBatch: "1000"
+      spark.driver.memoryOverheadFactor: "0.3"
+      spark.executor.memoryOverheadFactor: "0.3"
+
+    volumes:
+      - name: scripts
+        configMap:
+          name: quanton-finetune-demo-script
+      - name: demo-data
+        persistentVolumeClaim:
+          claimName: rag-and-fine-tuning-demo-pvc
+    driver:
+      cores: 1
+      memory: "4096m"
+      serviceAccount: spark-operator-spark
+      labels:
+        version: "4.1.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: demo-data
+          mountPath: /data/rag-demo
+    executor:
+      cores: 1
+      instances: 1
+      memory: "4096m"
+      labels:
+        version: "4.1.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: demo-data
+          mountPath: /data/rag-demo

--- a/examples/rag-and-fine-tuning/quanton-finetune-demo.yaml
+++ b/examples/rag-and-fine-tuning/quanton-finetune-demo.yaml
@@ -20,8 +20,7 @@ data:
         -> format("training_dataset")  -> validated Together SFT JSONL + _manifest.json
                                        -> tokenized parquet + token manifest
 
-    Nothing is installed: the image ships quanton_llm_training, and its `tokenized` extra is
-    transformers + jinja2, which are Rust tokenizers and pull no torch.
+    Nothing is installed: the image ships quanton_llm_training.
 
     Usage: finetune_demo.py <data_dir> [max_rows]
     """
@@ -39,9 +38,7 @@ data:
     MAX_ROWS = int(sys.argv[2]) if len(sys.argv) > 2 else 500
 
     TABLES, EXPORTS = f"{DATA}/tables", f"{DATA}/exports"
-    # An exported training dataset is immutable, so format("training_dataset") refuses to
-    # write into a path that already holds one. A UTC stamp gives each run its own version
-    # directory. The Hudi tables are the opposite contract on purpose: they upsert in place.
+    # Exported datasets are immutable, so each run writes its own versioned directory.
     VERSION = os.environ.get("QU_EXPORT_VERSION",
                              datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ"))
 
@@ -63,8 +60,6 @@ data:
                    .where(F.length("span") > 40))
 
     # Whitespace-normalised prefix match: find the chunk that contains each expert span.
-    # This is the grounding step -- a human lawyer marked the span, so the answer is not
-    # something the model invented.
     norm = lambda c: F.lower(F.regexp_replace(c, r"\s+", " "))  # noqa: E731
     positives = (annotations
                  .withColumn("span_key", F.substring(norm(F.col("span")), 1, 120))
@@ -125,8 +120,7 @@ data:
           .save(tokenized_path))
     print(f"[finetune-demo] tokenized parquet + manifest -> {tokenized_path}", flush=True)
 
-    # The writer produces the dataset in object storage and never uploads. The manifest's
-    # `load` section names the command the caller still owes.
+    # The writer never uploads. The manifest's `load` section names the upload command.
     for p in (jsonl_path, tokenized_path):
         for m in glob.glob(os.path.join(p, "_manifest.json")):
             print(f"\n[finetune-demo] _manifest.json ({os.path.basename(p)}):", flush=True)
@@ -146,23 +140,21 @@ spec:
   sparkApplicationSpec:
     type: Python
     mode: cluster
-    # Placeholder. The operator overrides it: sparkVersion 4.x + the default
-    # accelerator (native) resolve to onehouseConfig.quantonSpark4Image.
+    # Placeholder. sparkVersion 4.x + the default accelerator (native) resolve to
+    # onehouseConfig.quantonSpark4Image.
     image: "apache/spark:4.0.0"
     imagePullPolicy: IfNotPresent
     mainApplicationFile: "local:///mnt/scripts/finetune_demo.py"
     arguments:
       - "/data/rag-demo"
       - "500"
-    # 4.1.x selects the Spark 4 line. Quote it -- an unquoted 4.1 is a YAML number
-    # and the job is rejected.
+    # Selects the Spark 4 image. Quote it so YAML reads a string.
     sparkVersion: "4.1.0"
     restartPolicy:
       type: Never
     sparkConf:
-      # The operator regenerates spark.properties from this block and bypasses the image's
-      # /opt/spark/conf/spark-defaults.conf entirely, so the Hudi + Lance wiring the image
-      # bakes in MUST be repeated here or neither format is available at runtime.
+      # The operator builds spark.properties from this block, so the Hudi + Lance
+      # settings are set here.
       spark.driver.extraClassPath: "/opt/spark/user-jars/*"
       spark.executor.extraClassPath: "/opt/spark/user-jars/*"
       spark.sql.extensions: org.apache.spark.sql.hudi.HoodieSparkSessionExtension

--- a/examples/rag-and-fine-tuning/quanton-rag-demo.yaml
+++ b/examples/rag-and-fine-tuning/quanton-rag-demo.yaml
@@ -66,6 +66,12 @@ data:
         - Python workers on an executor share /tmp, so the install runs once under a lock
           with a marker file, and any transformers already imported is purged from
           sys.modules before the fresh copy loads.
+        - All three names are bounded by major version. sentence-transformers 5 and later
+          route encode() through a processor table with no entry for a plain text BERT
+          tokenizer, and transformers 4.x does not catch the error huggingface_hub 1.x
+          raises for a model repo that has no chat template. Either one fails per worker,
+          so a stage can lose every retry on one partition while the others pass. Working
+          set: sentence-transformers 4.1.0, transformers 4.57.6, huggingface_hub 0.36.2.
         """
         import fcntl
 
@@ -83,7 +89,7 @@ data:
                     "--target", PYDEPS, "--upgrade",
                     "--index-url", "https://download.pytorch.org/whl/cpu",
                     "--extra-index-url", "https://pypi.org/simple",
-                    "sentence-transformers", "transformers",
+                    "sentence-transformers<5", "transformers<5", "huggingface_hub<1",
                 ])
                 with open(marker, "w") as m:
                     m.write("ok")
@@ -104,7 +110,7 @@ data:
             print(f"[rag-demo] corpus already staged at {DUMP}", flush=True)
             return
         subprocess.check_call([sys.executable, "-m", "pip", "install",
-                               "--quiet", "--target", PYDEPS, "huggingface_hub"])
+                               "--quiet", "--target", PYDEPS, "huggingface_hub<1"])
         if PYDEPS not in sys.path:
             sys.path.insert(0, PYDEPS)
         import shutil
@@ -344,7 +350,8 @@ spec:
       spark.sql.shuffle.partitions: "8"
       spark.sql.execution.arrow.maxRecordsPerBatch: "1000"
       spark.driver.memoryOverheadFactor: "0.3"
-      spark.executor.memoryOverheadFactor: "0.3"
+      # the embedding worker holds torch outside the JVM, in the overhead budget
+      spark.executor.memoryOverheadFactor: "1.2"
 
     volumes:
       - name: scripts

--- a/examples/rag-and-fine-tuning/quanton-rag-demo.yaml
+++ b/examples/rag-and-fine-tuning/quanton-rag-demo.yaml
@@ -58,31 +58,14 @@ data:
     def ensure_sentence_transformers():
         """Install sentence-transformers into PYDEPS once per pod, then import it.
 
-        The image ships quanton_unstructured, Hudi and Lance, but deliberately not
-        sentence-transformers: torch would roughly double the image, and embedding is job
-        code rather than connector code. So the job installs it. Three things this has to
-        get right, all of them learned by getting them wrong first:
+        The image does not bundle sentence-transformers (torch is large and embedding is
+        job code), so the job installs it:
 
-        1. --index-url .../whl/cpu. The default wheel drags in nvidia/ and triton/ -- about
-           3.5 GB of CUDA runtime that never executes on a CPU node. Pinning the CPU build
-           takes the install from ~5.0 GB to ~1.4 GB.
-
-        2. transformers is named explicitly, with --upgrade. The image already ships it (via
-           quanton-llm-training[tokenized]) resolved against NO torch, so a bare
-           `--target PYDEPS sentence-transformers` finds it already satisfied and skips it.
-           That leaves sentence_transformers loading from PYDEPS while transformers loads
-           from the image's site-packages -- a torch-less transformers under a torch that
-           now exists. It then detects torch as available and dies in a class body where
-           torch was never bound: "NameError: name 'torch' is not defined".
-
-        3. A marker file, checked under the lock, plus a sys.modules purge. Every Python
-           worker on an executor calls this and they share one /tmp, so the install must
-           happen once. Testing importability instead of a marker is a time-of-check race:
-           pip writes --target incrementally, so a worker can import a half-written tree.
-           And because Spark reuses Python workers, a worker that imported during that
-           window keeps the image's transformers in sys.modules forever -- when a submodule
-           raises, Python evicts only that submodule and leaves the parent package cached.
-           Purging it is what makes the retry actually recover.
+        - The CPU wheel index skips the CUDA packages, which never run on a CPU node.
+        - transformers is upgraded alongside so both packages resolve from PYDEPS.
+        - Python workers on an executor share /tmp, so the install runs once under a lock
+          with a marker file, and any transformers already imported is purged from
+          sys.modules before the fresh copy loads.
         """
         import fcntl
 
@@ -107,7 +90,7 @@ data:
             import importlib
             importlib.invalidate_caches()
 
-        # Drop any transformers this interpreter cached from the image before PYDEPS existed.
+        # Reload transformers from PYDEPS if an earlier import cached a different copy.
         for name in [m for m in list(sys.modules)
                      if m == "transformers" or m.startswith("transformers.")]:
             del sys.modules[name]
@@ -140,8 +123,7 @@ data:
                 if p.suffix.lower() == ".pdf"]
         for p in pdfs:
             shutil.copy2(p, dump / p.name)
-        # The CSV is a structured straggler on purpose: the reader flags it rather than
-        # dragging it through a text extractor.
+        # The CSV is included on purpose: the reader flags it as structured data.
         shutil.copy2(raw / "CUAD_v1" / "master_clauses.csv", dump / "master_clauses.csv")
         print(f"[rag-demo] staged {len(pdfs)} PDFs + annotations CSV -> {dump}", flush=True)
 
@@ -156,9 +138,7 @@ data:
              .option("hoodie.datasource.write.recordkey.field", record_key)
              .option("hoodie.datasource.write.precombine.field", precombine))
         if base_format == "LANCE":
-            # The Lance writer only exists in HoodieSparkFileWriterFactory; without the SPARK
-            # record type the write routes through the Avro factory and throws
-            # "Lance base file format is currently only supported with the Spark engine".
+            # LANCE base files are written through the Spark-native record path.
             w = (w.option("hoodie.datasource.write.record.merger.impls",
                           "org.apache.hudi.DefaultSparkRecordMerger")
                  .option("hoodie.write.record.merge.mode", "COMMIT_TIME_ORDERING"))
@@ -167,7 +147,7 @@ data:
 
 
     ensure_corpus()
-    # Before the session, and before anything can import the image's torch-less transformers.
+    # Install before the session starts so the driver and the workers import the same copy.
     ensure_sentence_transformers()
 
     spark = SparkSession.builder.appName("rag_demo").getOrCreate()
@@ -191,8 +171,7 @@ data:
          .agg(F.count("uri").alias("files"))
          .orderBy(F.desc("files")).show(20, truncate=False))
 
-    # A file the reader cannot parse does not stop the job -- it lands as a row carrying the
-    # status and the reason, so failures stay queryable.
+    # Unparseable files land as rows carrying the status and reason, so failures stay queryable.
     failures = docs.where(F.col("parse_status") == "FAILED")
     if failures.select("uri").head(1):
         failures.select("uri", "parse_error").show(5, truncate=80)
@@ -249,8 +228,7 @@ data:
     if MAX_CHUNKS:
         chunks = chunks.limit(MAX_CHUNKS)
 
-    # Hudi 1.2.0 bug: an empty-projection scan returns 0 rows on a lance table, so a bare
-    # count() lies. Always aggregate over a column.
+    # Count over a named column.
     n_chunks = chunks.agg(F.count("chunk_id").alias("c")).first()["c"]
     print(f"\n[rag-demo] === step 3: embedding {n_chunks} chunks with {MODEL} ===", flush=True)
 
@@ -343,23 +321,21 @@ spec:
   sparkApplicationSpec:
     type: Python
     mode: cluster
-    # Placeholder. The operator overrides it: sparkVersion 4.x + the default
-    # accelerator (native) resolve to onehouseConfig.quantonSpark4Image.
+    # Placeholder. sparkVersion 4.x + the default accelerator (native) resolve to
+    # onehouseConfig.quantonSpark4Image.
     image: "apache/spark:4.0.0"
     imagePullPolicy: IfNotPresent
     mainApplicationFile: "local:///mnt/scripts/rag_demo.py"
     arguments:
       - "/data/rag-demo"
       - "400"
-    # 4.1.x selects the Spark 4 line. Quote it -- an unquoted 4.1 is a YAML number
-    # and the job is rejected.
+    # Selects the Spark 4 image. Quote it so YAML reads a string.
     sparkVersion: "4.1.0"
     restartPolicy:
       type: Never
     sparkConf:
-      # The operator regenerates spark.properties from this block and bypasses the image's
-      # /opt/spark/conf/spark-defaults.conf entirely, so the Hudi + Lance wiring the image
-      # bakes in MUST be repeated here or neither format is available at runtime.
+      # The operator builds spark.properties from this block, so the Hudi + Lance
+      # settings are set here.
       spark.driver.extraClassPath: "/opt/spark/user-jars/*"
       spark.executor.extraClassPath: "/opt/spark/user-jars/*"
       spark.sql.extensions: org.apache.spark.sql.hudi.HoodieSparkSessionExtension

--- a/examples/rag-and-fine-tuning/quanton-rag-demo.yaml
+++ b/examples/rag-and-fine-tuning/quanton-rag-demo.yaml
@@ -1,0 +1,401 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rag-and-fine-tuning-demo-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quanton-rag-demo-script
+  namespace: default
+data:
+  rag_demo.py: |
+    #!/usr/bin/env python3
+    """RAG on your lakehouse — the four steps from the blog, on Kubernetes.
+
+      https://quanton.dev/blog/rag-on-documents/
+
+      step 1  spark.read.format("quanton_unstructured")  -> one row per file
+      step 2  -> contract_documents   Hudi COW, LANCE base files
+              -> contract_annotations Hudi COW, PARQUET base files (the clause labels)
+      step 3  explode chunks -> BGE embeddings via mapInPandas -> contract_chunks (LANCE)
+      step 4  retrieval as SQL: cosine top-k, the same statement joined against the
+              relational table, and a GROUP BY that needs no vector search at all
+
+    Corpus is CUAD (real commercial contracts, CC-BY-4.0), ~100 MB, fetched on first run.
+
+    Usage: rag_demo.py <data_dir> [max_chunks]
+    """
+
+    import os
+    import subprocess
+    import sys
+
+    from pyspark.sql import SparkSession
+    from pyspark.sql import functions as F
+
+    DATA = sys.argv[1] if len(sys.argv) > 1 else "/data/rag-demo"
+    # Parsing all 510 contracts is cheap; embedding every chunk is not. 400 chunks keeps
+    # a minikube run to a few minutes. Raise it (or pass 0 for all ~17.8k) on a real cluster.
+    MAX_CHUNKS = int(sys.argv[2]) if len(sys.argv) > 2 else 400
+
+    DUMP, TABLES = f"{DATA}/dump", f"{DATA}/tables"
+    MODEL = "BAAI/bge-base-en-v1.5"   # 768-dim, Apache-2.0, 512-token window
+    EMBED_SCHEMA = ("uri string, file_name string, pos int, chunk string, "
+                    "chunk_id string, embedding array<float>")
+
+    PYDEPS = "/tmp/pydeps"
+    os.environ.setdefault("HF_HOME", f"{DATA}/hf")
+
+
+    def ensure_sentence_transformers():
+        """Install sentence-transformers into PYDEPS once per pod, then import it.
+
+        The image ships quanton_unstructured, Hudi and Lance, but deliberately not
+        sentence-transformers: torch would roughly double the image, and embedding is job
+        code rather than connector code. So the job installs it. Three things this has to
+        get right, all of them learned by getting them wrong first:
+
+        1. --index-url .../whl/cpu. The default wheel drags in nvidia/ and triton/ -- about
+           3.5 GB of CUDA runtime that never executes on a CPU node. Pinning the CPU build
+           takes the install from ~5.0 GB to ~1.4 GB.
+
+        2. transformers is named explicitly, with --upgrade. The image already ships it (via
+           quanton-llm-training[tokenized]) resolved against NO torch, so a bare
+           `--target PYDEPS sentence-transformers` finds it already satisfied and skips it.
+           That leaves sentence_transformers loading from PYDEPS while transformers loads
+           from the image's site-packages -- a torch-less transformers under a torch that
+           now exists. It then detects torch as available and dies in a class body where
+           torch was never bound: "NameError: name 'torch' is not defined".
+
+        3. A marker file, checked under the lock, plus a sys.modules purge. Every Python
+           worker on an executor calls this and they share one /tmp, so the install must
+           happen once. Testing importability instead of a marker is a time-of-check race:
+           pip writes --target incrementally, so a worker can import a half-written tree.
+           And because Spark reuses Python workers, a worker that imported during that
+           window keeps the image's transformers in sys.modules forever -- when a submodule
+           raises, Python evicts only that submodule and leaves the parent package cached.
+           Purging it is what makes the retry actually recover.
+        """
+        import fcntl
+
+        if PYDEPS not in sys.path:
+            sys.path.insert(0, PYDEPS)
+
+        marker = os.path.join(PYDEPS, ".install-complete")
+        os.makedirs(PYDEPS, exist_ok=True)
+
+        with open("/tmp/pydeps.lock", "w") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+            if not os.path.exists(marker):
+                subprocess.check_call([
+                    sys.executable, "-m", "pip", "install", "--no-cache-dir", "--quiet",
+                    "--target", PYDEPS, "--upgrade",
+                    "--index-url", "https://download.pytorch.org/whl/cpu",
+                    "--extra-index-url", "https://pypi.org/simple",
+                    "sentence-transformers", "transformers",
+                ])
+                with open(marker, "w") as m:
+                    m.write("ok")
+            import importlib
+            importlib.invalidate_caches()
+
+        # Drop any transformers this interpreter cached from the image before PYDEPS existed.
+        for name in [m for m in list(sys.modules)
+                     if m == "transformers" or m.startswith("transformers.")]:
+            del sys.modules[name]
+
+        import sentence_transformers  # noqa: F401
+
+
+    def ensure_corpus():
+        """Fetch CUAD and stage a NAS-style mixed dump: 510 PDFs + the annotations CSV."""
+        if os.path.isdir(DUMP) and len(os.listdir(DUMP)) > 100:
+            print(f"[rag-demo] corpus already staged at {DUMP}", flush=True)
+            return
+        subprocess.check_call([sys.executable, "-m", "pip", "install",
+                               "--quiet", "--target", PYDEPS, "huggingface_hub"])
+        if PYDEPS not in sys.path:
+            sys.path.insert(0, PYDEPS)
+        import shutil
+        from pathlib import Path
+
+        from huggingface_hub import snapshot_download
+
+        raw = Path(DATA) / "cuad"
+        snapshot_download(
+            repo_id="theatticusproject/cuad", repo_type="dataset", local_dir=raw,
+            allow_patterns=["CUAD_v1/full_contract_pdf/**", "CUAD_v1/master_clauses.csv"],
+        )
+        dump = Path(DUMP)
+        dump.mkdir(parents=True, exist_ok=True)
+        pdfs = [p for p in (raw / "CUAD_v1" / "full_contract_pdf").rglob("*")
+                if p.suffix.lower() == ".pdf"]
+        for p in pdfs:
+            shutil.copy2(p, dump / p.name)
+        # The CSV is a structured straggler on purpose: the reader flags it rather than
+        # dragging it through a text extractor.
+        shutil.copy2(raw / "CUAD_v1" / "master_clauses.csv", dump / "master_clauses.csv")
+        print(f"[rag-demo] staged {len(pdfs)} PDFs + annotations CSV -> {dump}", flush=True)
+
+
+    def write_hudi(df, name, record_key, precombine, base_format):
+        """COW Hudi write. LANCE base files need Hudi's Spark-native record type."""
+        path = f"{TABLES}/{name}"
+        w = (df.write.format("hudi")
+             .option("hoodie.table.name", name)
+             .option("hoodie.table.base.file.format", base_format)
+             .option("hoodie.datasource.write.table.type", "COPY_ON_WRITE")
+             .option("hoodie.datasource.write.recordkey.field", record_key)
+             .option("hoodie.datasource.write.precombine.field", precombine))
+        if base_format == "LANCE":
+            # The Lance writer only exists in HoodieSparkFileWriterFactory; without the SPARK
+            # record type the write routes through the Avro factory and throws
+            # "Lance base file format is currently only supported with the Spark engine".
+            w = (w.option("hoodie.datasource.write.record.merger.impls",
+                          "org.apache.hudi.DefaultSparkRecordMerger")
+                 .option("hoodie.write.record.merge.mode", "COMMIT_TIME_ORDERING"))
+        w.mode("overwrite").save(path)
+        return path
+
+
+    ensure_corpus()
+    # Before the session, and before anything can import the image's torch-less transformers.
+    ensure_sentence_transformers()
+
+    spark = SparkSession.builder.appName("rag_demo").getOrCreate()
+    spark.sparkContext.setLogLevel("WARN")
+
+
+    def read_hudi(name):
+        return spark.read.format("hudi").load(f"{TABLES}/{name}")
+
+
+    # --- Step 1 -- read the documents ------------------------------------------
+    import quanton_unstructured
+
+    quanton_unstructured.register(spark)
+
+    docs = spark.read.format("quanton_unstructured").load(DUMP)
+    docs.cache()
+
+    print("\n[rag-demo] === step 1: what was lying in the dump ===", flush=True)
+    (docs.groupBy("content_type", "parse_status", "parser_used")
+         .agg(F.count("uri").alias("files"))
+         .orderBy(F.desc("files")).show(20, truncate=False))
+
+    # A file the reader cannot parse does not stop the job -- it lands as a row carrying the
+    # status and the reason, so failures stay queryable.
+    failures = docs.where(F.col("parse_status") == "FAILED")
+    if failures.select("uri").head(1):
+        failures.select("uri", "parse_error").show(5, truncate=80)
+
+    # --- Step 2 -- land it in Hudi on Lance base files -------------------------
+    parsed = (docs.where(F.col("parse_status") == "SUCCESS")
+              .withColumn("file_name", F.element_at(F.split(F.col("uri"), "/"), -1))
+              .select("uri", "file_name", "size", "content_type",
+                      "text", "chunks", "parser_used"))
+    print(f"[rag-demo] contract_documents (LANCE) -> "
+          f"{write_hudi(parsed, 'contract_documents', 'uri', 'size', 'LANCE')}", flush=True)
+
+    raw = (spark.read.option("header", True).option("multiLine", True).option("escape", '"')
+           .csv(f"{DUMP}/master_clauses.csv"))
+
+
+    @F.udf("array<string>")
+    def parse_spans(cell):
+        """Clause columns hold a python-repr list of annotated spans; '[]' when absent."""
+        import ast
+        if not cell or cell.strip() in ("", "[]"):
+            return []
+        try:
+            v = ast.literal_eval(cell)
+            return [str(s) for s in v] if isinstance(v, list) else [str(v)]
+        except (ValueError, SyntaxError):
+            return [cell]
+
+
+    categories = [c for c in raw.columns
+                  if c != "Filename" and not c.endswith("-Answer")
+                  and f"{c}-Answer" in raw.columns]
+    long_rows = F.explode(F.array(*[
+        F.struct(F.lit(c).alias("clause_type"),
+                 F.col(f"`{c}`").alias("clause_text"),
+                 F.col(f"`{c}-Answer`").alias("answer"))
+        for c in categories])).alias("kv")
+
+    annotations = (raw.select(F.col("Filename").alias("file_name"), long_rows)
+                   .select("file_name",
+                           F.col("kv.clause_type").alias("clause_type"),
+                           parse_spans(F.col("kv.clause_text")).alias("clause_spans"),
+                           F.col("kv.answer").alias("answer"))
+                   .where(F.size("clause_spans") > 0)
+                   .withColumn("annotation_id", F.concat_ws("::", "file_name", "clause_type")))
+    print(f"[rag-demo] contract_annotations (PARQUET) -> "
+          f"{write_hudi(annotations, 'contract_annotations', 'annotation_id', 'file_name', 'PARQUET')}",
+          flush=True)
+
+    # --- Step 3 -- embed the chunks --------------------------------------------
+    chunks = (read_hudi("contract_documents")
+              .select("uri", "file_name", F.posexplode("chunks").alias("pos", "chunk"))
+              .withColumn("chunk_id", F.concat_ws("#", "uri", "pos")))
+    if MAX_CHUNKS:
+        chunks = chunks.limit(MAX_CHUNKS)
+
+    # Hudi 1.2.0 bug: an empty-projection scan returns 0 rows on a lance table, so a bare
+    # count() lies. Always aggregate over a column.
+    n_chunks = chunks.agg(F.count("chunk_id").alias("c")).first()["c"]
+    print(f"\n[rag-demo] === step 3: embedding {n_chunks} chunks with {MODEL} ===", flush=True)
+
+
+    def embed_partition(iterator):
+        """mapInPandas: the model loads once per worker, not once per row."""
+        ensure_sentence_transformers()
+        from sentence_transformers import SentenceTransformer
+
+        model = SentenceTransformer(MODEL, device="cpu")
+        for pdf in iterator:
+            vecs = model.encode(pdf["chunk"].tolist(), batch_size=32,
+                                normalize_embeddings=True, show_progress_bar=False)
+            pdf["embedding"] = [v.tolist() for v in vecs]
+            yield pdf
+
+
+    embedded = chunks.repartition(4).mapInPandas(embed_partition, schema=EMBED_SCHEMA)
+    print(f"[rag-demo] contract_chunks (LANCE) -> "
+          f"{write_hudi(embedded, 'contract_chunks', 'chunk_id', 'pos', 'LANCE')}", flush=True)
+
+    # --- Step 4 -- retrieve with SQL -------------------------------------------
+    read_hudi("contract_chunks").createOrReplaceTempView("chunks")
+    read_hudi("contract_annotations").createOrReplaceTempView("annotations")
+    read_hudi("contract_documents").createOrReplaceTempView("documents")
+
+    question = "Which contracts prevent a party from competing or working with competitors?"
+    from sentence_transformers import SentenceTransformer
+
+    q_vec = (SentenceTransformer(MODEL, device="cpu")
+             .encode([question], normalize_embeddings=True)[0].tolist())
+    spark.sql(f"SELECT array({','.join(f'{x}F' for x in q_vec)}) v").createOrReplaceTempView("q")
+
+    # Both vectors have unit length, so the dot product IS the cosine.
+    print(f"\n[rag-demo] === step 4: retrieval is a query ===\n{question!r}", flush=True)
+    spark.sql("""
+        WITH scored AS (
+            SELECT c.file_name, c.pos, c.chunk,
+                   aggregate(zip_with(c.embedding, q.v, (a, b) -> a * b),
+                             0.0F, (acc, x) -> acc + x) AS cosine
+            FROM chunks c CROSS JOIN q
+        )
+        SELECT file_name, pos, round(cosine, 4) AS cosine,
+               substring(chunk, 1, 100) AS excerpt
+        FROM scored ORDER BY cosine DESC LIMIT 5
+    """).createOrReplaceTempView("top_hits")
+    spark.table("top_hits").show(truncate=False)
+
+    # Context needs more than similarity. The embedding does not hold "expert-labeled
+    # Non-Compete"; a column in the relational table does, and it sits next to the chunks.
+    print("[rag-demo] === the same statement joins the relational table ===", flush=True)
+    spark.sql("""
+        SELECT t.file_name, t.cosine,
+               CASE WHEN a.annotation_id IS NOT NULL
+                    THEN 'YES (expert-labeled)' ELSE 'no' END AS has_non_compete
+        FROM top_hits t
+        LEFT JOIN annotations a
+          ON a.file_name = t.file_name AND a.clause_type = 'Non-Compete'
+        ORDER BY t.cosine DESC
+    """).show(truncate=False)
+
+    # Some questions are not retrieval at all. A CSV supplied the labels, PDFs supplied the
+    # chunks, and one GROUP BY reads both -- across PARQUET and LANCE base files.
+    print("[rag-demo] === coverage: one GROUP BY over parquet labels x lance chunks ===", flush=True)
+    spark.sql("""
+        SELECT a.clause_type,
+               COUNT(a.annotation_id)  AS annotated_contracts,
+               SUM(size(d.chunks))     AS retrievable_chunks
+        FROM annotations a
+        JOIN documents d ON a.file_name = d.file_name
+        WHERE a.clause_type IN ('Anti-Assignment', 'Termination For Convenience',
+                                'Exclusivity', 'Non-Compete', 'Ip Ownership Assignment')
+        GROUP BY a.clause_type ORDER BY annotated_contracts DESC
+    """).show(truncate=False)
+
+    n_docs = spark.sql("SELECT COUNT(uri) c FROM documents").first()["c"]
+    n_vec = spark.sql("SELECT COUNT(chunk_id) c FROM chunks").first()["c"]
+    n_ann = spark.sql("SELECT COUNT(annotation_id) c FROM annotations").first()["c"]
+    print(f"\n[rag-demo] PASS — documents(lance)={n_docs} "
+          f"chunks(lance)={n_vec} annotations(parquet)={n_ann}", flush=True)
+    spark.stop()
+
+---
+apiVersion: quantonsparkoperator.onehouse.ai/v1beta2
+kind: QuantonSparkApplication
+metadata:
+  name: quanton-rag-demo
+  namespace: default
+spec:
+  sparkApplicationSpec:
+    type: Python
+    mode: cluster
+    # Placeholder. The operator overrides it: sparkVersion 4.x + the default
+    # accelerator (native) resolve to onehouseConfig.quantonSpark4Image.
+    image: "apache/spark:4.0.0"
+    imagePullPolicy: IfNotPresent
+    mainApplicationFile: "local:///mnt/scripts/rag_demo.py"
+    arguments:
+      - "/data/rag-demo"
+      - "400"
+    # 4.1.x selects the Spark 4 line. Quote it -- an unquoted 4.1 is a YAML number
+    # and the job is rejected.
+    sparkVersion: "4.1.0"
+    restartPolicy:
+      type: Never
+    sparkConf:
+      # The operator regenerates spark.properties from this block and bypasses the image's
+      # /opt/spark/conf/spark-defaults.conf entirely, so the Hudi + Lance wiring the image
+      # bakes in MUST be repeated here or neither format is available at runtime.
+      spark.driver.extraClassPath: "/opt/spark/user-jars/*"
+      spark.executor.extraClassPath: "/opt/spark/user-jars/*"
+      spark.sql.extensions: org.apache.spark.sql.hudi.HoodieSparkSessionExtension
+      spark.serializer: org.apache.spark.serializer.KryoSerializer
+      spark.kryo.registrator: org.apache.spark.HoodieSparkKryoRegistrar
+      spark.sql.shuffle.partitions: "8"
+      spark.sql.execution.arrow.maxRecordsPerBatch: "1000"
+      spark.driver.memoryOverheadFactor: "0.3"
+      spark.executor.memoryOverheadFactor: "0.3"
+
+    volumes:
+      - name: scripts
+        configMap:
+          name: quanton-rag-demo-script
+      - name: demo-data
+        persistentVolumeClaim:
+          claimName: rag-and-fine-tuning-demo-pvc
+    driver:
+      cores: 1
+      memory: "4096m"
+      serviceAccount: spark-operator-spark
+      labels:
+        version: "4.1.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: demo-data
+          mountPath: /data/rag-demo
+    executor:
+      cores: 1
+      instances: 1
+      memory: "4096m"
+      labels:
+        version: "4.1.0"
+      volumeMounts:
+        - name: scripts
+          mountPath: /mnt/scripts
+        - name: demo-data
+          mountPath: /data/rag-demo

--- a/examples/rag-and-fine-tuning/rag_demo.py
+++ b/examples/rag-and-fine-tuning/rag_demo.py
@@ -47,6 +47,12 @@ def ensure_sentence_transformers():
     - Python workers on an executor share /tmp, so the install runs once under a lock
       with a marker file, and any transformers already imported is purged from
       sys.modules before the fresh copy loads.
+    - All three names are bounded by major version. sentence-transformers 5 and later
+      route encode() through a processor table with no entry for a plain text BERT
+      tokenizer, and transformers 4.x does not catch the error huggingface_hub 1.x
+      raises for a model repo that has no chat template. Either one fails per worker,
+      so a stage can lose every retry on one partition while the others pass. Working
+      set: sentence-transformers 4.1.0, transformers 4.57.6, huggingface_hub 0.36.2.
     """
     import fcntl
 
@@ -64,7 +70,7 @@ def ensure_sentence_transformers():
                 "--target", PYDEPS, "--upgrade",
                 "--index-url", "https://download.pytorch.org/whl/cpu",
                 "--extra-index-url", "https://pypi.org/simple",
-                "sentence-transformers", "transformers",
+                "sentence-transformers<5", "transformers<5", "huggingface_hub<1",
             ])
             with open(marker, "w") as m:
                 m.write("ok")
@@ -85,7 +91,7 @@ def ensure_corpus():
         print(f"[rag-demo] corpus already staged at {DUMP}", flush=True)
         return
     subprocess.check_call([sys.executable, "-m", "pip", "install",
-                           "--quiet", "--target", PYDEPS, "huggingface_hub"])
+                           "--quiet", "--target", PYDEPS, "huggingface_hub<1"])
     if PYDEPS not in sys.path:
         sys.path.insert(0, PYDEPS)
     import shutil

--- a/examples/rag-and-fine-tuning/rag_demo.py
+++ b/examples/rag-and-fine-tuning/rag_demo.py
@@ -39,31 +39,14 @@ os.environ.setdefault("HF_HOME", f"{DATA}/hf")
 def ensure_sentence_transformers():
     """Install sentence-transformers into PYDEPS once per pod, then import it.
 
-    The image ships quanton_unstructured, Hudi and Lance, but deliberately not
-    sentence-transformers: torch would roughly double the image, and embedding is job
-    code rather than connector code. So the job installs it. Three things this has to
-    get right, all of them learned by getting them wrong first:
+    The image does not bundle sentence-transformers (torch is large and embedding is
+    job code), so the job installs it:
 
-    1. --index-url .../whl/cpu. The default wheel drags in nvidia/ and triton/ -- about
-       3.5 GB of CUDA runtime that never executes on a CPU node. Pinning the CPU build
-       takes the install from ~5.0 GB to ~1.4 GB.
-
-    2. transformers is named explicitly, with --upgrade. The image already ships it (via
-       quanton-llm-training[tokenized]) resolved against NO torch, so a bare
-       `--target PYDEPS sentence-transformers` finds it already satisfied and skips it.
-       That leaves sentence_transformers loading from PYDEPS while transformers loads
-       from the image's site-packages -- a torch-less transformers under a torch that
-       now exists. It then detects torch as available and dies in a class body where
-       torch was never bound: "NameError: name 'torch' is not defined".
-
-    3. A marker file, checked under the lock, plus a sys.modules purge. Every Python
-       worker on an executor calls this and they share one /tmp, so the install must
-       happen once. Testing importability instead of a marker is a time-of-check race:
-       pip writes --target incrementally, so a worker can import a half-written tree.
-       And because Spark reuses Python workers, a worker that imported during that
-       window keeps the image's transformers in sys.modules forever -- when a submodule
-       raises, Python evicts only that submodule and leaves the parent package cached.
-       Purging it is what makes the retry actually recover.
+    - The CPU wheel index skips the CUDA packages, which never run on a CPU node.
+    - transformers is upgraded alongside so both packages resolve from PYDEPS.
+    - Python workers on an executor share /tmp, so the install runs once under a lock
+      with a marker file, and any transformers already imported is purged from
+      sys.modules before the fresh copy loads.
     """
     import fcntl
 
@@ -88,7 +71,7 @@ def ensure_sentence_transformers():
         import importlib
         importlib.invalidate_caches()
 
-    # Drop any transformers this interpreter cached from the image before PYDEPS existed.
+    # Reload transformers from PYDEPS if an earlier import cached a different copy.
     for name in [m for m in list(sys.modules)
                  if m == "transformers" or m.startswith("transformers.")]:
         del sys.modules[name]
@@ -121,8 +104,7 @@ def ensure_corpus():
             if p.suffix.lower() == ".pdf"]
     for p in pdfs:
         shutil.copy2(p, dump / p.name)
-    # The CSV is a structured straggler on purpose: the reader flags it rather than
-    # dragging it through a text extractor.
+    # The CSV is included on purpose: the reader flags it as structured data.
     shutil.copy2(raw / "CUAD_v1" / "master_clauses.csv", dump / "master_clauses.csv")
     print(f"[rag-demo] staged {len(pdfs)} PDFs + annotations CSV -> {dump}", flush=True)
 
@@ -137,9 +119,7 @@ def write_hudi(df, name, record_key, precombine, base_format):
          .option("hoodie.datasource.write.recordkey.field", record_key)
          .option("hoodie.datasource.write.precombine.field", precombine))
     if base_format == "LANCE":
-        # The Lance writer only exists in HoodieSparkFileWriterFactory; without the SPARK
-        # record type the write routes through the Avro factory and throws
-        # "Lance base file format is currently only supported with the Spark engine".
+        # LANCE base files are written through the Spark-native record path.
         w = (w.option("hoodie.datasource.write.record.merger.impls",
                       "org.apache.hudi.DefaultSparkRecordMerger")
              .option("hoodie.write.record.merge.mode", "COMMIT_TIME_ORDERING"))
@@ -148,7 +128,7 @@ def write_hudi(df, name, record_key, precombine, base_format):
 
 
 ensure_corpus()
-# Before the session, and before anything can import the image's torch-less transformers.
+# Install before the session starts so the driver and the workers import the same copy.
 ensure_sentence_transformers()
 
 spark = SparkSession.builder.appName("rag_demo").getOrCreate()
@@ -172,8 +152,7 @@ print("\n[rag-demo] === step 1: what was lying in the dump ===", flush=True)
      .agg(F.count("uri").alias("files"))
      .orderBy(F.desc("files")).show(20, truncate=False))
 
-# A file the reader cannot parse does not stop the job -- it lands as a row carrying the
-# status and the reason, so failures stay queryable.
+# Unparseable files land as rows carrying the status and reason, so failures stay queryable.
 failures = docs.where(F.col("parse_status") == "FAILED")
 if failures.select("uri").head(1):
     failures.select("uri", "parse_error").show(5, truncate=80)
@@ -230,8 +209,7 @@ chunks = (read_hudi("contract_documents")
 if MAX_CHUNKS:
     chunks = chunks.limit(MAX_CHUNKS)
 
-# Hudi 1.2.0 bug: an empty-projection scan returns 0 rows on a lance table, so a bare
-# count() lies. Always aggregate over a column.
+# Count over a named column.
 n_chunks = chunks.agg(F.count("chunk_id").alias("c")).first()["c"]
 print(f"\n[rag-demo] === step 3: embedding {n_chunks} chunks with {MODEL} ===", flush=True)
 

--- a/examples/rag-and-fine-tuning/rag_demo.py
+++ b/examples/rag-and-fine-tuning/rag_demo.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""RAG on your lakehouse — the four steps from the blog, on Kubernetes.
+
+  https://quanton.dev/blog/rag-on-documents/
+
+  step 1  spark.read.format("quanton_unstructured")  -> one row per file
+  step 2  -> contract_documents   Hudi COW, LANCE base files
+          -> contract_annotations Hudi COW, PARQUET base files (the clause labels)
+  step 3  explode chunks -> BGE embeddings via mapInPandas -> contract_chunks (LANCE)
+  step 4  retrieval as SQL: cosine top-k, the same statement joined against the
+          relational table, and a GROUP BY that needs no vector search at all
+
+Corpus is CUAD (real commercial contracts, CC-BY-4.0), ~100 MB, fetched on first run.
+
+Usage: rag_demo.py <data_dir> [max_chunks]
+"""
+
+import os
+import subprocess
+import sys
+
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+
+DATA = sys.argv[1] if len(sys.argv) > 1 else "/data/rag-demo"
+# Parsing all 510 contracts is cheap; embedding every chunk is not. 400 chunks keeps
+# a minikube run to a few minutes. Raise it (or pass 0 for all ~17.8k) on a real cluster.
+MAX_CHUNKS = int(sys.argv[2]) if len(sys.argv) > 2 else 400
+
+DUMP, TABLES = f"{DATA}/dump", f"{DATA}/tables"
+MODEL = "BAAI/bge-base-en-v1.5"   # 768-dim, Apache-2.0, 512-token window
+EMBED_SCHEMA = ("uri string, file_name string, pos int, chunk string, "
+                "chunk_id string, embedding array<float>")
+
+PYDEPS = "/tmp/pydeps"
+os.environ.setdefault("HF_HOME", f"{DATA}/hf")
+
+
+def ensure_sentence_transformers():
+    """Install sentence-transformers into PYDEPS once per pod, then import it.
+
+    The image ships quanton_unstructured, Hudi and Lance, but deliberately not
+    sentence-transformers: torch would roughly double the image, and embedding is job
+    code rather than connector code. So the job installs it. Three things this has to
+    get right, all of them learned by getting them wrong first:
+
+    1. --index-url .../whl/cpu. The default wheel drags in nvidia/ and triton/ -- about
+       3.5 GB of CUDA runtime that never executes on a CPU node. Pinning the CPU build
+       takes the install from ~5.0 GB to ~1.4 GB.
+
+    2. transformers is named explicitly, with --upgrade. The image already ships it (via
+       quanton-llm-training[tokenized]) resolved against NO torch, so a bare
+       `--target PYDEPS sentence-transformers` finds it already satisfied and skips it.
+       That leaves sentence_transformers loading from PYDEPS while transformers loads
+       from the image's site-packages -- a torch-less transformers under a torch that
+       now exists. It then detects torch as available and dies in a class body where
+       torch was never bound: "NameError: name 'torch' is not defined".
+
+    3. A marker file, checked under the lock, plus a sys.modules purge. Every Python
+       worker on an executor calls this and they share one /tmp, so the install must
+       happen once. Testing importability instead of a marker is a time-of-check race:
+       pip writes --target incrementally, so a worker can import a half-written tree.
+       And because Spark reuses Python workers, a worker that imported during that
+       window keeps the image's transformers in sys.modules forever -- when a submodule
+       raises, Python evicts only that submodule and leaves the parent package cached.
+       Purging it is what makes the retry actually recover.
+    """
+    import fcntl
+
+    if PYDEPS not in sys.path:
+        sys.path.insert(0, PYDEPS)
+
+    marker = os.path.join(PYDEPS, ".install-complete")
+    os.makedirs(PYDEPS, exist_ok=True)
+
+    with open("/tmp/pydeps.lock", "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        if not os.path.exists(marker):
+            subprocess.check_call([
+                sys.executable, "-m", "pip", "install", "--no-cache-dir", "--quiet",
+                "--target", PYDEPS, "--upgrade",
+                "--index-url", "https://download.pytorch.org/whl/cpu",
+                "--extra-index-url", "https://pypi.org/simple",
+                "sentence-transformers", "transformers",
+            ])
+            with open(marker, "w") as m:
+                m.write("ok")
+        import importlib
+        importlib.invalidate_caches()
+
+    # Drop any transformers this interpreter cached from the image before PYDEPS existed.
+    for name in [m for m in list(sys.modules)
+                 if m == "transformers" or m.startswith("transformers.")]:
+        del sys.modules[name]
+
+    import sentence_transformers  # noqa: F401
+
+
+def ensure_corpus():
+    """Fetch CUAD and stage a NAS-style mixed dump: 510 PDFs + the annotations CSV."""
+    if os.path.isdir(DUMP) and len(os.listdir(DUMP)) > 100:
+        print(f"[rag-demo] corpus already staged at {DUMP}", flush=True)
+        return
+    subprocess.check_call([sys.executable, "-m", "pip", "install",
+                           "--quiet", "--target", PYDEPS, "huggingface_hub"])
+    if PYDEPS not in sys.path:
+        sys.path.insert(0, PYDEPS)
+    import shutil
+    from pathlib import Path
+
+    from huggingface_hub import snapshot_download
+
+    raw = Path(DATA) / "cuad"
+    snapshot_download(
+        repo_id="theatticusproject/cuad", repo_type="dataset", local_dir=raw,
+        allow_patterns=["CUAD_v1/full_contract_pdf/**", "CUAD_v1/master_clauses.csv"],
+    )
+    dump = Path(DUMP)
+    dump.mkdir(parents=True, exist_ok=True)
+    pdfs = [p for p in (raw / "CUAD_v1" / "full_contract_pdf").rglob("*")
+            if p.suffix.lower() == ".pdf"]
+    for p in pdfs:
+        shutil.copy2(p, dump / p.name)
+    # The CSV is a structured straggler on purpose: the reader flags it rather than
+    # dragging it through a text extractor.
+    shutil.copy2(raw / "CUAD_v1" / "master_clauses.csv", dump / "master_clauses.csv")
+    print(f"[rag-demo] staged {len(pdfs)} PDFs + annotations CSV -> {dump}", flush=True)
+
+
+def write_hudi(df, name, record_key, precombine, base_format):
+    """COW Hudi write. LANCE base files need Hudi's Spark-native record type."""
+    path = f"{TABLES}/{name}"
+    w = (df.write.format("hudi")
+         .option("hoodie.table.name", name)
+         .option("hoodie.table.base.file.format", base_format)
+         .option("hoodie.datasource.write.table.type", "COPY_ON_WRITE")
+         .option("hoodie.datasource.write.recordkey.field", record_key)
+         .option("hoodie.datasource.write.precombine.field", precombine))
+    if base_format == "LANCE":
+        # The Lance writer only exists in HoodieSparkFileWriterFactory; without the SPARK
+        # record type the write routes through the Avro factory and throws
+        # "Lance base file format is currently only supported with the Spark engine".
+        w = (w.option("hoodie.datasource.write.record.merger.impls",
+                      "org.apache.hudi.DefaultSparkRecordMerger")
+             .option("hoodie.write.record.merge.mode", "COMMIT_TIME_ORDERING"))
+    w.mode("overwrite").save(path)
+    return path
+
+
+ensure_corpus()
+# Before the session, and before anything can import the image's torch-less transformers.
+ensure_sentence_transformers()
+
+spark = SparkSession.builder.appName("rag_demo").getOrCreate()
+spark.sparkContext.setLogLevel("WARN")
+
+
+def read_hudi(name):
+    return spark.read.format("hudi").load(f"{TABLES}/{name}")
+
+
+# --- Step 1 -- read the documents ------------------------------------------
+import quanton_unstructured
+
+quanton_unstructured.register(spark)
+
+docs = spark.read.format("quanton_unstructured").load(DUMP)
+docs.cache()
+
+print("\n[rag-demo] === step 1: what was lying in the dump ===", flush=True)
+(docs.groupBy("content_type", "parse_status", "parser_used")
+     .agg(F.count("uri").alias("files"))
+     .orderBy(F.desc("files")).show(20, truncate=False))
+
+# A file the reader cannot parse does not stop the job -- it lands as a row carrying the
+# status and the reason, so failures stay queryable.
+failures = docs.where(F.col("parse_status") == "FAILED")
+if failures.select("uri").head(1):
+    failures.select("uri", "parse_error").show(5, truncate=80)
+
+# --- Step 2 -- land it in Hudi on Lance base files -------------------------
+parsed = (docs.where(F.col("parse_status") == "SUCCESS")
+          .withColumn("file_name", F.element_at(F.split(F.col("uri"), "/"), -1))
+          .select("uri", "file_name", "size", "content_type",
+                  "text", "chunks", "parser_used"))
+print(f"[rag-demo] contract_documents (LANCE) -> "
+      f"{write_hudi(parsed, 'contract_documents', 'uri', 'size', 'LANCE')}", flush=True)
+
+raw = (spark.read.option("header", True).option("multiLine", True).option("escape", '"')
+       .csv(f"{DUMP}/master_clauses.csv"))
+
+
+@F.udf("array<string>")
+def parse_spans(cell):
+    """Clause columns hold a python-repr list of annotated spans; '[]' when absent."""
+    import ast
+    if not cell or cell.strip() in ("", "[]"):
+        return []
+    try:
+        v = ast.literal_eval(cell)
+        return [str(s) for s in v] if isinstance(v, list) else [str(v)]
+    except (ValueError, SyntaxError):
+        return [cell]
+
+
+categories = [c for c in raw.columns
+              if c != "Filename" and not c.endswith("-Answer")
+              and f"{c}-Answer" in raw.columns]
+long_rows = F.explode(F.array(*[
+    F.struct(F.lit(c).alias("clause_type"),
+             F.col(f"`{c}`").alias("clause_text"),
+             F.col(f"`{c}-Answer`").alias("answer"))
+    for c in categories])).alias("kv")
+
+annotations = (raw.select(F.col("Filename").alias("file_name"), long_rows)
+               .select("file_name",
+                       F.col("kv.clause_type").alias("clause_type"),
+                       parse_spans(F.col("kv.clause_text")).alias("clause_spans"),
+                       F.col("kv.answer").alias("answer"))
+               .where(F.size("clause_spans") > 0)
+               .withColumn("annotation_id", F.concat_ws("::", "file_name", "clause_type")))
+print(f"[rag-demo] contract_annotations (PARQUET) -> "
+      f"{write_hudi(annotations, 'contract_annotations', 'annotation_id', 'file_name', 'PARQUET')}",
+      flush=True)
+
+# --- Step 3 -- embed the chunks --------------------------------------------
+chunks = (read_hudi("contract_documents")
+          .select("uri", "file_name", F.posexplode("chunks").alias("pos", "chunk"))
+          .withColumn("chunk_id", F.concat_ws("#", "uri", "pos")))
+if MAX_CHUNKS:
+    chunks = chunks.limit(MAX_CHUNKS)
+
+# Hudi 1.2.0 bug: an empty-projection scan returns 0 rows on a lance table, so a bare
+# count() lies. Always aggregate over a column.
+n_chunks = chunks.agg(F.count("chunk_id").alias("c")).first()["c"]
+print(f"\n[rag-demo] === step 3: embedding {n_chunks} chunks with {MODEL} ===", flush=True)
+
+
+def embed_partition(iterator):
+    """mapInPandas: the model loads once per worker, not once per row."""
+    ensure_sentence_transformers()
+    from sentence_transformers import SentenceTransformer
+
+    model = SentenceTransformer(MODEL, device="cpu")
+    for pdf in iterator:
+        vecs = model.encode(pdf["chunk"].tolist(), batch_size=32,
+                            normalize_embeddings=True, show_progress_bar=False)
+        pdf["embedding"] = [v.tolist() for v in vecs]
+        yield pdf
+
+
+embedded = chunks.repartition(4).mapInPandas(embed_partition, schema=EMBED_SCHEMA)
+print(f"[rag-demo] contract_chunks (LANCE) -> "
+      f"{write_hudi(embedded, 'contract_chunks', 'chunk_id', 'pos', 'LANCE')}", flush=True)
+
+# --- Step 4 -- retrieve with SQL -------------------------------------------
+read_hudi("contract_chunks").createOrReplaceTempView("chunks")
+read_hudi("contract_annotations").createOrReplaceTempView("annotations")
+read_hudi("contract_documents").createOrReplaceTempView("documents")
+
+question = "Which contracts prevent a party from competing or working with competitors?"
+from sentence_transformers import SentenceTransformer
+
+q_vec = (SentenceTransformer(MODEL, device="cpu")
+         .encode([question], normalize_embeddings=True)[0].tolist())
+spark.sql(f"SELECT array({','.join(f'{x}F' for x in q_vec)}) v").createOrReplaceTempView("q")
+
+# Both vectors have unit length, so the dot product IS the cosine.
+print(f"\n[rag-demo] === step 4: retrieval is a query ===\n{question!r}", flush=True)
+spark.sql("""
+    WITH scored AS (
+        SELECT c.file_name, c.pos, c.chunk,
+               aggregate(zip_with(c.embedding, q.v, (a, b) -> a * b),
+                         0.0F, (acc, x) -> acc + x) AS cosine
+        FROM chunks c CROSS JOIN q
+    )
+    SELECT file_name, pos, round(cosine, 4) AS cosine,
+           substring(chunk, 1, 100) AS excerpt
+    FROM scored ORDER BY cosine DESC LIMIT 5
+""").createOrReplaceTempView("top_hits")
+spark.table("top_hits").show(truncate=False)
+
+# Context needs more than similarity. The embedding does not hold "expert-labeled
+# Non-Compete"; a column in the relational table does, and it sits next to the chunks.
+print("[rag-demo] === the same statement joins the relational table ===", flush=True)
+spark.sql("""
+    SELECT t.file_name, t.cosine,
+           CASE WHEN a.annotation_id IS NOT NULL
+                THEN 'YES (expert-labeled)' ELSE 'no' END AS has_non_compete
+    FROM top_hits t
+    LEFT JOIN annotations a
+      ON a.file_name = t.file_name AND a.clause_type = 'Non-Compete'
+    ORDER BY t.cosine DESC
+""").show(truncate=False)
+
+# Some questions are not retrieval at all. A CSV supplied the labels, PDFs supplied the
+# chunks, and one GROUP BY reads both -- across PARQUET and LANCE base files.
+print("[rag-demo] === coverage: one GROUP BY over parquet labels x lance chunks ===", flush=True)
+spark.sql("""
+    SELECT a.clause_type,
+           COUNT(a.annotation_id)  AS annotated_contracts,
+           SUM(size(d.chunks))     AS retrievable_chunks
+    FROM annotations a
+    JOIN documents d ON a.file_name = d.file_name
+    WHERE a.clause_type IN ('Anti-Assignment', 'Termination For Convenience',
+                            'Exclusivity', 'Non-Compete', 'Ip Ownership Assignment')
+    GROUP BY a.clause_type ORDER BY annotated_contracts DESC
+""").show(truncate=False)
+
+n_docs = spark.sql("SELECT COUNT(uri) c FROM documents").first()["c"]
+n_vec = spark.sql("SELECT COUNT(chunk_id) c FROM chunks").first()["c"]
+n_ann = spark.sql("SELECT COUNT(annotation_id) c FROM annotations").first()["c"]
+print(f"\n[rag-demo] PASS — documents(lance)={n_docs} "
+      f"chunks(lance)={n_vec} annotations(parquet)={n_ann}", flush=True)
+spark.stop()


### PR DESCRIPTION
## What

Runnable companions to the two AI blog posts, plus a Claude Code skill (`/run-rag-demo`) that drives them on minikube.

| Blog | Manifest | Script |
|---|---|---|
| [RAG on Your Lakehouse](https://quanton.dev/blog/rag-on-documents/) | `quanton-rag-demo.yaml` | `rag_demo.py` |
| [From Lakehouse Tables to a Fine-Tuning Dataset](https://quanton.dev/blog/fine-tuning-from-lakehouse-tables/) | `quanton-finetune-demo.yaml` | `finetune_demo.py` |

Corpus is [CUAD](https://huggingface.co/datasets/theatticusproject/cuad) (510 contracts, CC-BY-4.0, ~100 MB), fetched on first run. Run the RAG demo first; the fine-tuning demo reads its tables. Each `.yaml` embeds its `.py` in a ConfigMap.

## Notes

- `sparkVersion: "4.1.0"` selects `onehouseConfig.quantonSpark4Image`. Requires chart 2.0.6+.
- `rag_demo.py` installs `sentence-transformers` from the CPU wheel index and embeds 400 chunks by default. Pass `0` to embed all ~17.8k.

## Verification

End to end on EKS with Spark 4.1: 510 PDFs parsed, 17,843 chunks embedded, all step 4 queries return. Both demos also pass on minikube with the default 400 chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
